### PR TITLE
chore(Cargo.toml): bump dependencies & trim closure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,14 +60,9 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "autocfg"
@@ -81,7 +76,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -91,25 +86,12 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "base64"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bit-set"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -140,6 +122,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -177,15 +164,6 @@ dependencies = [
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -222,20 +200,19 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.1.6"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "directories"
-version = "1.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs-sys 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -252,7 +229,7 @@ name = "dirs-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -263,15 +240,10 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fsevent"
@@ -287,7 +259,7 @@ name = "fsevent-sys"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -323,7 +295,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -340,7 +312,7 @@ name = "hermit-abi"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -364,7 +336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -372,7 +344,7 @@ name = "inotify-sys"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -380,7 +352,7 @@ name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -409,7 +381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -426,19 +398,19 @@ version = "1.2.0"
 dependencies = [
  "atomicwrites 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "ctrlc 3.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctrlc 3.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "directories 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "md5 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 5.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -455,7 +427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "md5"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -473,7 +445,7 @@ dependencies = [
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -509,7 +481,7 @@ version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -521,20 +493,19 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nix"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -551,7 +522,7 @@ dependencies = [
  "fsevent-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -580,7 +551,7 @@ name = "os_type"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -605,7 +576,7 @@ name = "parking_lot_core"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -658,21 +629,18 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "0.9.6"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bit-set 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -702,27 +670,9 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -732,19 +682,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -779,14 +720,6 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -794,51 +727,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rand_xorshift"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -866,18 +759,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -903,17 +796,6 @@ dependencies = [
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rusty-fork"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "ryu"
@@ -960,7 +842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "slog"
-version = "2.5.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -970,7 +852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -980,7 +862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1058,7 +940,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1103,7 +985,7 @@ name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1152,7 +1034,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1168,7 +1050,7 @@ name = "varlink"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1207,22 +1089,9 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "walkdir"
@@ -1295,33 +1164,29 @@ dependencies = [
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum atomicwrites 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6a2baf2feb820299c53c7ad1cc4f5914a220a1cb76d7ce321d2522a94b54651f"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-"checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e4036b9bf40f3cf16aba72a3d65e8a520fc4bafcdc7079aea8f848c58c5b5536"
 "checksum backtrace-sys 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-"checksum bit-set 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
-"checksum bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)" = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 "checksum chainerror 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "57f069866bc1ac85f8ad1806c01081ed2be733802f90a6447af76c75bedd9de4"
 "checksum chashmap 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff41a3c2c1e39921b9003de14bf0439c7b63a9039637c291e1a64925d8ddfa45"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 "checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
-"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-"checksum ctrlc 3.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d0b676fa23f995faf587496dcd1c80fead847ed58d2da52ac1caca9a72790dd2"
-"checksum directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "72d337a64190607d4fcca2cb78982c5dd57f4916e19696b48a575fa746b6cb0f"
+"checksum ctrlc 3.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c15b8ec3b5755a188c141c1f6a98e76de31b936209bf066b647979e2a84764a9"
+"checksum directories 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 "checksum filetime 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
-"checksum fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 "checksum fsevent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
 "checksum fsevent-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -1339,17 +1204,17 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
-"checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+"checksum libc 0.2.86 (registry+https://github.com/rust-lang/crates.io-index)" = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-"checksum md5 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
+"checksum md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum mio 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)" = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 "checksum mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
-"checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+"checksum nix 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 "checksum notify 5.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d742ae493f34bd2e20ec2f3c1276fc1981343a8efd7ef12bca4368d0303bed50"
 "checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 "checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
@@ -1363,41 +1228,33 @@ dependencies = [
 "checksum ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
-"checksum proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "01c477819b845fe023d33583ebf10c9f62518c8d79a0960ba5c36d6ac8a55a5b"
+"checksum proptest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12e6c80c1139113c28ee4670dc50cc42915228b51f56a9e407f0ec60f966646f"
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-"checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
-"checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
-"checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+"checksum regex 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+"checksum regex-syntax 0.6.22 (registry+https://github.com/rust-lang/crates.io-index)" = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 "checksum remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-"checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
 "checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 "checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 "checksum serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
+"checksum slog 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 "checksum slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c44c89dd8b0ae4537d1ae318353eaf7840b4869c536e31c41e963d1ea523ee6"
 "checksum slog-term 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bab1d807cf71129b05ce36914e1dbb6fbfbdecaf686301cb457f4fa967f9f5b6"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
@@ -1426,9 +1283,7 @@ dependencies = [
 "checksum varlink_generator 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a56e7bf98749ac88a93149700cbddb9da8b9639b54d2d87958d872a38d28db9"
 "checksum varlink_parser 4.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a63258ed1db0f33125967976d717708be22f165089fca9b12a9c5c42328be4b1"
 "checksum vec1 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a53a12216d700fcf70bd690b23485687dc05e4d7ffb6470d87e37cb8118dbfd1"
-"checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -24,7 +24,6 @@ rec {
         (cratesIO.crates."md5"."${deps."lorri"."1.2.0"."md5"}" deps)
         (cratesIO.crates."nix"."${deps."lorri"."1.2.0"."nix"}" deps)
         (cratesIO.crates."notify"."${deps."lorri"."1.2.0"."notify"}" deps)
-        (cratesIO.crates."proptest"."${deps."lorri"."1.2.0"."proptest"}" deps)
         (cratesIO.crates."regex"."${deps."lorri"."1.2.0"."regex"}" deps)
         (cratesIO.crates."serde"."${deps."lorri"."1.2.0"."serde"}" deps)
         (cratesIO.crates."serde_derive"."${deps."lorri"."1.2.0"."serde_derive"}" deps)
@@ -56,7 +55,6 @@ rec {
       md5."${deps.lorri."1.2.0".md5}".default = true;
       nix."${deps.lorri."1.2.0".nix}".default = true;
       notify."${deps.lorri."1.2.0".notify}".default = true;
-      proptest."${deps.lorri."1.2.0".proptest}".default = true;
       regex."${deps.lorri."1.2.0".regex}".default = true;
       serde."${deps.lorri."1.2.0".serde}".default = true;
       serde_derive."${deps.lorri."1.2.0".serde_derive}".default = true;
@@ -64,7 +62,12 @@ rec {
       slog."${deps.lorri."1.2.0".slog}".default = true;
       slog_scope."${deps.lorri."1.2.0".slog_scope}".default = true;
       slog_term."${deps.lorri."1.2.0".slog_term}".default = true;
-      structopt."${deps.lorri."1.2.0".structopt}".default = true;
+      structopt = fold recursiveUpdate {} [
+        { "${deps.lorri."1.2.0".structopt}"."color" = true; }
+        { "${deps.lorri."1.2.0".structopt}"."no_cargo" = true; }
+        { "${deps.lorri."1.2.0".structopt}"."suggestions" = true; }
+        { "${deps.lorri."1.2.0".structopt}".default = (f.structopt."${deps.lorri."1.2.0".structopt}".default or false); }
+      ];
       tempfile."${deps.lorri."1.2.0".tempfile}".default = true;
       varlink."${deps.lorri."1.2.0".varlink}".default = true;
       varlink_generator."${deps.lorri."1.2.0".varlink_generator}".default = true;
@@ -79,7 +82,6 @@ rec {
       (cratesIO.features_.md5."${deps."lorri"."1.2.0"."md5"}" deps)
       (cratesIO.features_.nix."${deps."lorri"."1.2.0"."nix"}" deps)
       (cratesIO.features_.notify."${deps."lorri"."1.2.0"."notify"}" deps)
-      (cratesIO.features_.proptest."${deps."lorri"."1.2.0"."proptest"}" deps)
       (cratesIO.features_.regex."${deps."lorri"."1.2.0"."regex"}" deps)
       (cratesIO.features_.serde."${deps."lorri"."1.2.0"."serde"}" deps)
       (cratesIO.features_.serde_derive."${deps."lorri"."1.2.0"."serde_derive"}" deps)
@@ -121,26 +123,21 @@ rec {
   };
   deps.atty."0.2.14" = {
     hermit_abi = "0.1.14";
-    libc = "0.2.71";
+    libc = "0.2.86";
     winapi = "0.3.8";
   };
-  deps.autocfg."0.1.7" = {};
   deps.autocfg."1.0.0" = {};
   deps.backtrace."0.3.44" = {
     backtrace_sys = "0.1.35";
     cfg_if = "0.1.10";
-    libc = "0.2.71";
+    libc = "0.2.86";
     rustc_demangle = "0.1.16";
   };
   deps.backtrace_sys."0.1.35" = {
-    libc = "0.2.71";
+    libc = "0.2.86";
     cc = "1.0.54";
   };
   deps.base64."0.11.0" = {};
-  deps.bit_set."0.5.2" = {
-    bit_vec = "0.6.2";
-  };
-  deps.bit_vec."0.6.2" = {};
   deps.bitflags."1.2.1" = {};
   deps.blake2b_simd."0.5.10" = {
     arrayref = "0.3.6";
@@ -150,6 +147,7 @@ rec {
   deps.byteorder."1.3.4" = {};
   deps.cc."1.0.54" = {};
   deps.cfg_if."0.1.10" = {};
+  deps.cfg_if."1.0.0" = {};
   deps.chainerror."0.4.3" = {};
   deps.chashmap."2.2.2" = {
     owning_ref = "0.3.3";
@@ -166,11 +164,7 @@ rec {
     strsim = "0.8.0";
     textwrap = "0.11.0";
     unicode_width = "0.1.7";
-    vec_map = "0.8.2";
     ansi_term = "0.11.0";
-  };
-  deps.cloudabi."0.0.3" = {
-    bitflags = "1.2.1";
   };
   deps.constant_time_eq."0.1.5" = {};
   deps.crossbeam_channel."0.3.9" = {
@@ -185,13 +179,12 @@ rec {
     lazy_static = "1.4.0";
     autocfg = "1.0.0";
   };
-  deps.ctrlc."3.1.6" = {
-    nix = "0.17.0";
+  deps.ctrlc."3.1.8" = {
+    nix = "0.20.0";
     winapi = "0.3.8";
   };
-  deps.directories."1.0.2" = {
-    libc = "0.2.71";
-    winapi = "0.3.8";
+  deps.directories."3.0.1" = {
+    dirs_sys = "0.3.5";
   };
   deps.dirs."2.0.2" = {
     cfg_if = "0.1.10";
@@ -199,22 +192,21 @@ rec {
   };
   deps.dirs_sys."0.3.5" = {
     redox_users = "0.3.4";
-    libc = "0.2.71";
+    libc = "0.2.86";
     winapi = "0.3.8";
   };
   deps.filetime."0.2.10" = {
     cfg_if = "0.1.10";
     redox_syscall = "0.1.56";
-    libc = "0.2.71";
+    libc = "0.2.86";
     winapi = "0.3.8";
   };
-  deps.fnv."1.0.7" = {};
   deps.fsevent."0.4.0" = {
     bitflags = "1.2.1";
     fsevent_sys = "2.0.1";
   };
   deps.fsevent_sys."2.0.1" = {
-    libc = "0.2.71";
+    libc = "0.2.86";
   };
   deps.fuchsia_cprng."0.1.1" = {};
   deps.fuchsia_zircon."0.3.3" = {
@@ -228,13 +220,13 @@ rec {
   deps.getrandom."0.1.14" = {
     cfg_if = "0.1.10";
     wasi = "0.9.0+wasi-snapshot-preview1";
-    libc = "0.2.71";
+    libc = "0.2.86";
   };
   deps.heck."0.3.1" = {
     unicode_segmentation = "1.6.0";
   };
   deps.hermit_abi."0.1.14" = {
-    libc = "0.2.71";
+    libc = "0.2.86";
   };
   deps.human_panic."1.0.3" = {
     backtrace = "0.3.44";
@@ -248,13 +240,13 @@ rec {
   deps.inotify."0.7.1" = {
     bitflags = "1.2.1";
     inotify_sys = "0.1.3";
-    libc = "0.2.71";
+    libc = "0.2.86";
   };
   deps.inotify_sys."0.1.3" = {
-    libc = "0.2.71";
+    libc = "0.2.86";
   };
   deps.iovec."0.1.4" = {
-    libc = "0.2.71";
+    libc = "0.2.86";
   };
   deps.itoa."0.4.6" = {};
   deps.kernel32_sys."0.2.2" = {
@@ -263,26 +255,25 @@ rec {
   };
   deps.lazy_static."1.4.0" = {};
   deps.lazycell."1.2.1" = {};
-  deps.libc."0.2.71" = {};
+  deps.libc."0.2.86" = {};
   deps.log."0.4.8" = {
     cfg_if = "0.1.10";
   };
   deps.lorri."1.2.0" = {
     atomicwrites = "0.2.5";
     crossbeam_channel = "0.3.9";
-    ctrlc = "3.1.6";
-    directories = "1.0.2";
+    ctrlc = "3.1.8";
+    directories = "3.0.1";
     human_panic = "1.0.3";
     lazy_static = "1.4.0";
-    md5 = "0.6.1";
-    nix = "0.14.1";
+    md5 = "0.7.0";
+    nix = "0.20.0";
     notify = "5.0.0-pre.1";
-    proptest = "0.9.6";
-    regex = "1.3.9";
+    regex = "1.4.3";
     serde = "1.0.114";
     serde_derive = "1.0.114";
     serde_json = "1.0.55";
-    slog = "2.5.2";
+    slog = "2.7.0";
     slog_scope = "4.3.0";
     slog_term = "2.6.0";
     structopt = "0.2.18";
@@ -292,7 +283,7 @@ rec {
     varlink_generator = "9.0.0";
   };
   deps.maybe_uninit."2.0.0" = {};
-  deps.md5."0.6.1" = {};
+  deps.md5."0.7.0" = {};
   deps.memchr."2.3.3" = {};
   deps.mio."0.6.22" = {
     cfg_if = "0.1.10";
@@ -302,7 +293,7 @@ rec {
     slab = "0.4.2";
     fuchsia_zircon = "0.3.3";
     fuchsia_zircon_sys = "0.3.3";
-    libc = "0.2.71";
+    libc = "0.2.86";
     kernel32_sys = "0.2.2";
     miow = "0.2.1";
     winapi = "0.2.8";
@@ -321,20 +312,19 @@ rec {
   };
   deps.net2."0.2.34" = {
     cfg_if = "0.1.10";
-    libc = "0.2.71";
+    libc = "0.2.86";
     winapi = "0.3.8";
   };
   deps.nix."0.14.1" = {
     bitflags = "1.2.1";
     cfg_if = "0.1.10";
-    libc = "0.2.71";
+    libc = "0.2.86";
     void = "1.0.2";
   };
-  deps.nix."0.17.0" = {
+  deps.nix."0.20.0" = {
     bitflags = "1.2.1";
-    cfg_if = "0.1.10";
-    libc = "0.2.71";
-    void = "1.0.2";
+    cfg_if = "1.0.0";
+    libc = "0.2.86";
   };
   deps.notify."5.0.0-pre.1" = {
     anymap = "0.12.1";
@@ -342,7 +332,7 @@ rec {
     chashmap = "2.2.2";
     crossbeam_channel = "0.3.9";
     filetime = "0.2.10";
-    libc = "0.2.71";
+    libc = "0.2.86";
     walkdir = "2.3.1";
     inotify = "0.7.1";
     mio = "0.6.22";
@@ -360,7 +350,7 @@ rec {
     autocfg = "1.0.0";
   };
   deps.os_type."2.2.0" = {
-    regex = "1.3.9";
+    regex = "1.4.3";
   };
   deps.owning_ref."0.3.3" = {
     stable_deref_trait = "1.1.1";
@@ -372,7 +362,7 @@ rec {
   deps.parking_lot_core."0.2.14" = {
     rand = "0.4.6";
     smallvec = "0.6.13";
-    libc = "0.2.71";
+    libc = "0.2.86";
     winapi = "0.3.8";
   };
   deps.peg."0.6.2" = {
@@ -392,19 +382,16 @@ rec {
   deps.proc_macro2."1.0.18" = {
     unicode_xid = "0.2.0";
   };
-  deps.proptest."0.9.6" = {
-    bit_set = "0.5.2";
+  deps.proptest."0.10.1" = {
     bitflags = "1.2.1";
     byteorder = "1.3.4";
     lazy_static = "1.4.0";
     num_traits = "0.2.12";
     quick_error = "1.2.3";
-    rand = "0.6.5";
-    rand_chacha = "0.1.1";
-    rand_xorshift = "0.1.1";
-    regex_syntax = "0.6.18";
-    rusty_fork = "0.2.2";
-    tempfile = "3.1.0";
+    rand = "0.7.3";
+    rand_chacha = "0.2.2";
+    rand_xorshift = "0.2.0";
+    regex_syntax = "0.6.22";
   };
   deps.quick_error."1.2.3" = {};
   deps.quote."0.6.13" = {
@@ -417,31 +404,14 @@ rec {
     rand_core = "0.3.1";
     rdrand = "0.4.0";
     fuchsia_cprng = "0.1.1";
-    libc = "0.2.71";
-    winapi = "0.3.8";
-  };
-  deps.rand."0.6.5" = {
-    rand_chacha = "0.1.1";
-    rand_core = "0.4.2";
-    rand_hc = "0.1.0";
-    rand_isaac = "0.1.1";
-    rand_jitter = "0.1.4";
-    rand_os = "0.1.3";
-    rand_pcg = "0.1.2";
-    rand_xorshift = "0.1.1";
-    autocfg = "0.1.7";
-    libc = "0.2.71";
+    libc = "0.2.86";
     winapi = "0.3.8";
   };
   deps.rand."0.7.3" = {
     rand_core = "0.5.1";
     rand_chacha = "0.2.2";
     rand_hc = "0.2.0";
-    libc = "0.2.71";
-  };
-  deps.rand_chacha."0.1.1" = {
-    rand_core = "0.3.1";
-    autocfg = "0.1.7";
+    libc = "0.2.86";
   };
   deps.rand_chacha."0.2.2" = {
     ppv_lite86 = "0.2.8";
@@ -454,34 +424,11 @@ rec {
   deps.rand_core."0.5.1" = {
     getrandom = "0.1.14";
   };
-  deps.rand_hc."0.1.0" = {
-    rand_core = "0.3.1";
-  };
   deps.rand_hc."0.2.0" = {
     rand_core = "0.5.1";
   };
-  deps.rand_isaac."0.1.1" = {
-    rand_core = "0.3.1";
-  };
-  deps.rand_jitter."0.1.4" = {
-    rand_core = "0.4.2";
-    libc = "0.2.71";
-    winapi = "0.3.8";
-  };
-  deps.rand_os."0.1.3" = {
-    rand_core = "0.4.2";
-    rdrand = "0.4.0";
-    cloudabi = "0.0.3";
-    fuchsia_cprng = "0.1.1";
-    libc = "0.2.71";
-    winapi = "0.3.8";
-  };
-  deps.rand_pcg."0.1.2" = {
-    rand_core = "0.4.2";
-    autocfg = "0.1.7";
-  };
-  deps.rand_xorshift."0.1.1" = {
-    rand_core = "0.3.1";
+  deps.rand_xorshift."0.2.0" = {
+    rand_core = "0.5.1";
   };
   deps.rdrand."0.4.0" = {
     rand_core = "0.3.1";
@@ -492,13 +439,13 @@ rec {
     redox_syscall = "0.1.56";
     rust_argon2 = "0.7.0";
   };
-  deps.regex."1.3.9" = {
+  deps.regex."1.4.3" = {
     aho_corasick = "0.7.12";
     memchr = "2.3.3";
-    regex_syntax = "0.6.18";
+    regex_syntax = "0.6.22";
     thread_local = "1.0.1";
   };
-  deps.regex_syntax."0.6.18" = {};
+  deps.regex_syntax."0.6.22" = {};
   deps.remove_dir_all."0.5.3" = {
     winapi = "0.3.8";
   };
@@ -509,12 +456,6 @@ rec {
     crossbeam_utils = "0.7.2";
   };
   deps.rustc_demangle."0.1.16" = {};
-  deps.rusty_fork."0.2.2" = {
-    fnv = "1.0.7";
-    quick_error = "1.2.3";
-    tempfile = "3.1.0";
-    wait_timeout = "0.2.0";
-  };
   deps.ryu."1.0.5" = {};
   deps.same_file."1.0.6" = {
     winapi_util = "0.1.5";
@@ -531,16 +472,16 @@ rec {
     serde = "1.0.114";
   };
   deps.slab."0.4.2" = {};
-  deps.slog."2.5.2" = {};
+  deps.slog."2.7.0" = {};
   deps.slog_scope."4.3.0" = {
     arc_swap = "0.4.7";
     lazy_static = "1.4.0";
-    slog = "2.5.2";
+    slog = "2.7.0";
   };
   deps.slog_term."2.6.0" = {
     atty = "0.2.14";
     chrono = "0.4.11";
-    slog = "2.5.2";
+    slog = "2.7.0";
     term = "0.6.1";
     thread_local = "1.0.1";
   };
@@ -578,7 +519,7 @@ rec {
     rand = "0.7.3";
     remove_dir_all = "0.5.3";
     redox_syscall = "0.1.56";
-    libc = "0.2.71";
+    libc = "0.2.86";
     winapi = "0.3.8";
   };
   deps.term."0.6.1" = {
@@ -595,7 +536,7 @@ rec {
     lazy_static = "1.4.0";
   };
   deps.time."0.1.43" = {
-    libc = "0.2.71";
+    libc = "0.2.86";
     winapi = "0.3.8";
   };
   deps.toml."0.5.6" = {
@@ -613,7 +554,7 @@ rec {
   deps.unicode_xid."0.2.0" = {};
   deps.unix_socket."0.5.0" = {
     cfg_if = "0.1.10";
-    libc = "0.2.71";
+    libc = "0.2.86";
   };
   deps.uuid."0.8.1" = {
     rand = "0.7.3";
@@ -623,7 +564,7 @@ rec {
     serde_derive = "1.0.114";
     serde_json = "1.0.55";
     tempfile = "3.1.0";
-    libc = "0.2.71";
+    libc = "0.2.86";
     unix_socket = "0.5.0";
     uds_windows = "0.1.4";
     winapi = "0.3.8";
@@ -642,11 +583,7 @@ rec {
     peg = "0.6.2";
   };
   deps.vec1."1.5.0" = {};
-  deps.vec_map."0.8.2" = {};
   deps.void."1.0.2" = {};
-  deps.wait_timeout."0.2.0" = {
-    libc = "0.2.71";
-  };
   deps.walkdir."2.3.1" = {
     same_file = "1.0.6";
     winapi = "0.3.8";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,28 +11,56 @@ homepage = "https://github.com/nix-community/lorri"
 license = "Apache-2.0"
 edition = "2018"
 
+# before updating dependencies: we want to keep the rustc compatible with 1.41.0 for now (start of 2020).
 [dependencies]
-atomicwrites = "0.2.3"
-crossbeam-channel = "0.3.8"
-ctrlc = { version = "3.1.6", features = ["termination"] }
-directories = "1.0.2"
-lazy_static = "1.2.0"
-md5  = "0.6.1"
-nix = "0.14.0"
+# central features
 notify = "= 5.0.0-pre.1"
-proptest = "0.9.1"
-regex = "1.1.0"
+atomicwrites = "0.2.5"
+crossbeam-channel = "0.3.8"
+nix = "0.20.0"
+regex = "1.4.3"
+tempfile = "3.1.0"
+# TODO: update to 0.3
+structopt.version = "0.2"
+structopt.default-features = false
+structopt.features = [
+    # "default",
+    "suggestions",
+    "color",
+    # "wrap_help",
+    # "yaml",
+    # "debug",
+    "no_cargo",
+    # "doc" (enables yaml)
+  ]
+# logging
+slog = "2.7.0"
+slog-scope = "4.3.0"
+slog-term = "2.5.0"
+# serialization
 serde = "1.0.88"
 serde_derive = "1.0.88"
 serde_json = "1.0.38"
-slog = "2.5.2"
-slog-scope = "4.3.0"
-slog-term = "2.5.0"
-structopt = "0.2"
-tempfile = "3.0.7"
 varlink = "10.0.0"
+# nice-to-have
+ctrlc = { version = "3.1.8", features = ["termination"] }
+directories = "3.0.1"
+lazy_static = "1.4.0"
+md5  = "0.7.0"
 vec1 = "1.1.0"
+# TODO: might want to remove? Big footprint?
 human-panic = "1.0.3"
+
+[dev-dependencies]
+# 1.0.0 requires at least rust 1.50
+proptest.version = "0.10.1"
+proptest.default-features = false
+proptest.features = [
+  "std",
+  # reenable if proptest kills the test runner
+  # "fork",
+  # "timeout"
+]
 
 [build-dependencies]
 varlink_generator = "9.0.0"

--- a/nix/carnix/crates-io.nix
+++ b/nix/carnix/crates-io.nix
@@ -247,21 +247,6 @@ rec {
 
 
 # end
-# autocfg-0.1.7
-
-  crates.autocfg."0.1.7" = deps: { features?(features_.autocfg."0.1.7" deps {}) }: buildRustCrate {
-    crateName = "autocfg";
-    version = "0.1.7";
-    description = "Automatic cfg for Rust compiler features";
-    authors = [ "Josh Stone <cuviper@gmail.com>" ];
-    sha256 = "01iq4rs9kanj88pbwjxzqp5k4bgdsvz3y398nljz441rfws11mi4";
-  };
-  features_.autocfg."0.1.7" = deps: f: updateFeatures f (rec {
-    autocfg."0.1.7".default = (f.autocfg."0.1.7".default or true);
-  }) [];
-
-
-# end
 # autocfg-1.0.0
 
   crates.autocfg."1.0.0" = deps: { features?(features_.autocfg."1.0.0" deps {}) }: buildRustCrate {
@@ -459,66 +444,6 @@ rec {
 
 
 # end
-# bit-set-0.5.2
-
-  crates.bit_set."0.5.2" = deps: { features?(features_.bit_set."0.5.2" deps {}) }: buildRustCrate {
-    crateName = "bit-set";
-    version = "0.5.2";
-    description = "A set of bits";
-    authors = [ "Alexis Beingessner <a.beingessner@gmail.com>" ];
-    sha256 = "1wz0dgjhn2naf1cqw5kvbwqyvvb05g9lld92n5wjjz7jjw4sf1lq";
-    dependencies = mapFeatures features ([
-      (crates."bit_vec"."${deps."bit_set"."0.5.2"."bit_vec"}" deps)
-    ]);
-    features = mkFeatures (features."bit_set"."0.5.2" or {});
-  };
-  features_.bit_set."0.5.2" = deps: f: updateFeatures f (rec {
-    bit_set = fold recursiveUpdate {} [
-      { "0.5.2"."std" =
-        (f.bit_set."0.5.2"."std" or false) ||
-        (f.bit_set."0.5.2".default or false) ||
-        (bit_set."0.5.2"."default" or false); }
-      { "0.5.2".default = (f.bit_set."0.5.2".default or true); }
-    ];
-    bit_vec = fold recursiveUpdate {} [
-      { "${deps.bit_set."0.5.2".bit_vec}"."std" =
-        (f.bit_vec."${deps.bit_set."0.5.2".bit_vec}"."std" or false) ||
-        (bit_set."0.5.2"."std" or false) ||
-        (f."bit_set"."0.5.2"."std" or false); }
-      { "${deps.bit_set."0.5.2".bit_vec}".default = (f.bit_vec."${deps.bit_set."0.5.2".bit_vec}".default or false); }
-    ];
-  }) [
-    (features_.bit_vec."${deps."bit_set"."0.5.2"."bit_vec"}" deps)
-  ];
-
-
-# end
-# bit-vec-0.6.2
-
-  crates.bit_vec."0.6.2" = deps: { features?(features_.bit_vec."0.6.2" deps {}) }: buildRustCrate {
-    crateName = "bit-vec";
-    version = "0.6.2";
-    description = "A vector of bits";
-    authors = [ "Alexis Beingessner <a.beingessner@gmail.com>" ];
-    sha256 = "0k3qncqadnggr249bfy1c2spdg45d1vz74k7rrhm76rpsz7bax50";
-    dependencies = mapFeatures features ([
-]);
-    features = mkFeatures (features."bit_vec"."0.6.2" or {});
-  };
-  features_.bit_vec."0.6.2" = deps: f: updateFeatures f (rec {
-    bit_vec = fold recursiveUpdate {} [
-      { "0.6.2"."std" =
-        (f.bit_vec."0.6.2"."std" or false) ||
-        (f.bit_vec."0.6.2".default or false) ||
-        (bit_vec."0.6.2"."default" or false) ||
-        (f.bit_vec."0.6.2".serde_std or false) ||
-        (bit_vec."0.6.2"."serde_std" or false); }
-      { "0.6.2".default = (f.bit_vec."0.6.2".default or true); }
-    ];
-  }) [];
-
-
-# end
 # bitflags-1.2.1
 
   crates.bitflags."1.2.1" = deps: { features?(features_.bitflags."1.2.1" deps {}) }: buildRustCrate {
@@ -648,6 +573,35 @@ rec {
 
 
 # end
+# cfg-if-1.0.0
+
+  crates.cfg_if."1.0.0" = deps: { features?(features_.cfg_if."1.0.0" deps {}) }: buildRustCrate {
+    crateName = "cfg-if";
+    version = "1.0.0";
+    description = "A macro to ergonomically define an item depending on a large number of #[cfg]\nparameters. Structured like an if-else chain, the first matching branch is the\nitem that gets emitted.\n";
+    authors = [ "Alex Crichton <alex@alexcrichton.com>" ];
+    edition = "2018";
+    sha256 = "1fzidq152hnxhg4lj6r2gv4jpnn8yivp27z6q6xy7w6v0dp6bai9";
+    dependencies = mapFeatures features ([
+]);
+    features = mkFeatures (features."cfg_if"."1.0.0" or {});
+  };
+  features_.cfg_if."1.0.0" = deps: f: updateFeatures f (rec {
+    cfg_if = fold recursiveUpdate {} [
+      { "1.0.0"."compiler_builtins" =
+        (f.cfg_if."1.0.0"."compiler_builtins" or false) ||
+        (f.cfg_if."1.0.0".rustc-dep-of-std or false) ||
+        (cfg_if."1.0.0"."rustc-dep-of-std" or false); }
+      { "1.0.0"."core" =
+        (f.cfg_if."1.0.0"."core" or false) ||
+        (f.cfg_if."1.0.0".rustc-dep-of-std or false) ||
+        (cfg_if."1.0.0"."rustc-dep-of-std" or false); }
+      { "1.0.0".default = (f.cfg_if."1.0.0".default or true); }
+    ];
+  }) [];
+
+
+# end
 # chainerror-0.4.3
 
   crates.chainerror."0.4.3" = deps: { features?(features_.chainerror."0.4.3" deps {}) }: buildRustCrate {
@@ -757,8 +711,7 @@ rec {
       (crates."unicode_width"."${deps."clap"."2.33.1"."unicode_width"}" deps)
     ]
       ++ (if features.clap."2.33.1".atty or false then [ (crates.atty."${deps."clap"."2.33.1".atty}" deps) ] else [])
-      ++ (if features.clap."2.33.1".strsim or false then [ (crates.strsim."${deps."clap"."2.33.1".strsim}" deps) ] else [])
-      ++ (if features.clap."2.33.1".vec_map or false then [ (crates.vec_map."${deps."clap"."2.33.1".vec_map}" deps) ] else []))
+      ++ (if features.clap."2.33.1".strsim or false then [ (crates.strsim."${deps."clap"."2.33.1".strsim}" deps) ] else []))
       ++ (if !(kernel == "windows") then mapFeatures features ([
     ]
       ++ (if features.clap."2.33.1".ansi_term or false then [ (crates.ansi_term."${deps."clap"."2.33.1".ansi_term}" deps) ] else [])) else []);
@@ -820,44 +773,13 @@ rec {
       { "${deps.clap."2.33.1".textwrap}".default = true; }
     ];
     unicode_width."${deps.clap."2.33.1".unicode_width}".default = true;
-    vec_map."${deps.clap."2.33.1".vec_map}".default = true;
   }) [
     (features_.atty."${deps."clap"."2.33.1"."atty"}" deps)
     (features_.bitflags."${deps."clap"."2.33.1"."bitflags"}" deps)
     (features_.strsim."${deps."clap"."2.33.1"."strsim"}" deps)
     (features_.textwrap."${deps."clap"."2.33.1"."textwrap"}" deps)
     (features_.unicode_width."${deps."clap"."2.33.1"."unicode_width"}" deps)
-    (features_.vec_map."${deps."clap"."2.33.1"."vec_map"}" deps)
     (features_.ansi_term."${deps."clap"."2.33.1"."ansi_term"}" deps)
-  ];
-
-
-# end
-# cloudabi-0.0.3
-
-  crates.cloudabi."0.0.3" = deps: { features?(features_.cloudabi."0.0.3" deps {}) }: buildRustCrate {
-    crateName = "cloudabi";
-    version = "0.0.3";
-    description = "Low level interface to CloudABI. Contains all syscalls and related types.";
-    authors = [ "Nuxi (https://nuxi.nl/) and contributors" ];
-    sha256 = "1z9lby5sr6vslfd14d6igk03s7awf91mxpsfmsp3prxbxlk0x7h5";
-    libPath = "cloudabi.rs";
-    dependencies = mapFeatures features ([
-    ]
-      ++ (if features.cloudabi."0.0.3".bitflags or false then [ (crates.bitflags."${deps."cloudabi"."0.0.3".bitflags}" deps) ] else []));
-    features = mkFeatures (features."cloudabi"."0.0.3" or {});
-  };
-  features_.cloudabi."0.0.3" = deps: f: updateFeatures f (rec {
-    bitflags."${deps.cloudabi."0.0.3".bitflags}".default = true;
-    cloudabi = fold recursiveUpdate {} [
-      { "0.0.3"."bitflags" =
-        (f.cloudabi."0.0.3"."bitflags" or false) ||
-        (f.cloudabi."0.0.3".default or false) ||
-        (cloudabi."0.0.3"."default" or false); }
-      { "0.0.3".default = (f.cloudabi."0.0.3".default or true); }
-    ];
-  }) [
-    (features_.bitflags."${deps."cloudabi"."0.0.3"."bitflags"}" deps)
   ];
 
 
@@ -974,68 +896,57 @@ rec {
 
 
 # end
-# ctrlc-3.1.6
+# ctrlc-3.1.8
 
-  crates.ctrlc."3.1.6" = deps: { features?(features_.ctrlc."3.1.6" deps {}) }: buildRustCrate {
+  crates.ctrlc."3.1.8" = deps: { features?(features_.ctrlc."3.1.8" deps {}) }: buildRustCrate {
     crateName = "ctrlc";
-    version = "3.1.6";
+    version = "3.1.8";
     description = "Easy Ctrl-C handler for Rust projects";
     authors = [ "Antti Keränen <detegr@gmail.com>" ];
-    sha256 = "1680g2jw2r2z3020p1linfjim5jv8ddvapfd3z1083nr557m1bpc";
+    edition = "2018";
+    sha256 = "16gc3zgifh2myhda04b2lkc3ydmg1jwbgsxgb8vxz6i8yp1v4575";
     dependencies = (if (kernel == "linux" || kernel == "darwin") then mapFeatures features ([
-      (crates."nix"."${deps."ctrlc"."3.1.6"."nix"}" deps)
+      (crates."nix"."${deps."ctrlc"."3.1.8"."nix"}" deps)
     ]) else [])
       ++ (if kernel == "windows" then mapFeatures features ([
-      (crates."winapi"."${deps."ctrlc"."3.1.6"."winapi"}" deps)
+      (crates."winapi"."${deps."ctrlc"."3.1.8"."winapi"}" deps)
     ]) else []);
-    features = mkFeatures (features."ctrlc"."3.1.6" or {});
+    features = mkFeatures (features."ctrlc"."3.1.8" or {});
   };
-  features_.ctrlc."3.1.6" = deps: f: updateFeatures f (rec {
-    ctrlc."3.1.6".default = (f.ctrlc."3.1.6".default or true);
-    nix."${deps.ctrlc."3.1.6".nix}".default = true;
+  features_.ctrlc."3.1.8" = deps: f: updateFeatures f (rec {
+    ctrlc."3.1.8".default = (f.ctrlc."3.1.8".default or true);
+    nix."${deps.ctrlc."3.1.8".nix}".default = true;
     winapi = fold recursiveUpdate {} [
-      { "${deps.ctrlc."3.1.6".winapi}"."consoleapi" = true; }
-      { "${deps.ctrlc."3.1.6".winapi}"."handleapi" = true; }
-      { "${deps.ctrlc."3.1.6".winapi}"."synchapi" = true; }
-      { "${deps.ctrlc."3.1.6".winapi}"."winbase" = true; }
-      { "${deps.ctrlc."3.1.6".winapi}".default = true; }
+      { "${deps.ctrlc."3.1.8".winapi}"."consoleapi" = true; }
+      { "${deps.ctrlc."3.1.8".winapi}"."handleapi" = true; }
+      { "${deps.ctrlc."3.1.8".winapi}"."synchapi" = true; }
+      { "${deps.ctrlc."3.1.8".winapi}"."winbase" = true; }
+      { "${deps.ctrlc."3.1.8".winapi}".default = true; }
     ];
   }) [
-    (features_.nix."${deps."ctrlc"."3.1.6"."nix"}" deps)
-    (features_.winapi."${deps."ctrlc"."3.1.6"."winapi"}" deps)
+    (features_.nix."${deps."ctrlc"."3.1.8"."nix"}" deps)
+    (features_.winapi."${deps."ctrlc"."3.1.8"."winapi"}" deps)
   ];
 
 
 # end
-# directories-1.0.2
+# directories-3.0.1
 
-  crates.directories."1.0.2" = deps: { features?(features_.directories."1.0.2" deps {}) }: buildRustCrate {
+  crates.directories."3.0.1" = deps: { features?(features_.directories."3.0.1" deps {}) }: buildRustCrate {
     crateName = "directories";
-    version = "1.0.2";
+    version = "3.0.1";
     description = "A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS.";
     authors = [ "Simon Ochsenreither <simon@ochsenreither.de>" ];
-    sha256 = "07gr8bcs77i8sjr24c9frj9gsbs4csp91s895s5y253qaacqzz0m";
-    dependencies = (if (kernel == "linux" || kernel == "darwin") then mapFeatures features ([
-      (crates."libc"."${deps."directories"."1.0.2"."libc"}" deps)
-    ]) else [])
-      ++ (if kernel == "windows" then mapFeatures features ([
-      (crates."winapi"."${deps."directories"."1.0.2"."winapi"}" deps)
-    ]) else []);
+    sha256 = "16gvghamz34a6nmp95ygycg9nax35l3r6mwavgd1lzxwlkhwdph4";
+    dependencies = mapFeatures features ([
+      (crates."dirs_sys"."${deps."directories"."3.0.1"."dirs_sys"}" deps)
+    ]);
   };
-  features_.directories."1.0.2" = deps: f: updateFeatures f (rec {
-    directories."1.0.2".default = (f.directories."1.0.2".default or true);
-    libc."${deps.directories."1.0.2".libc}".default = true;
-    winapi = fold recursiveUpdate {} [
-      { "${deps.directories."1.0.2".winapi}"."knownfolders" = true; }
-      { "${deps.directories."1.0.2".winapi}"."objbase" = true; }
-      { "${deps.directories."1.0.2".winapi}"."shlobj" = true; }
-      { "${deps.directories."1.0.2".winapi}"."winbase" = true; }
-      { "${deps.directories."1.0.2".winapi}"."winerror" = true; }
-      { "${deps.directories."1.0.2".winapi}".default = true; }
-    ];
+  features_.directories."3.0.1" = deps: f: updateFeatures f (rec {
+    directories."3.0.1".default = (f.directories."3.0.1".default or true);
+    dirs_sys."${deps.directories."3.0.1".dirs_sys}".default = true;
   }) [
-    (features_.libc."${deps."directories"."1.0.2"."libc"}" deps)
-    (features_.winapi."${deps."directories"."1.0.2"."winapi"}" deps)
+    (features_.dirs_sys."${deps."directories"."3.0.1"."dirs_sys"}" deps)
   ];
 
 
@@ -1141,29 +1052,6 @@ rec {
     (features_.libc."${deps."filetime"."0.2.10"."libc"}" deps)
     (features_.winapi."${deps."filetime"."0.2.10"."winapi"}" deps)
   ];
-
-
-# end
-# fnv-1.0.7
-
-  crates.fnv."1.0.7" = deps: { features?(features_.fnv."1.0.7" deps {}) }: buildRustCrate {
-    crateName = "fnv";
-    version = "1.0.7";
-    description = "Fowler–Noll–Vo hash function";
-    authors = [ "Alex Crichton <alex@alexcrichton.com>" ];
-    sha256 = "020gqgq68jwwy3rvlzaiaywyhpb5282frf05kfbv3cgh64v7xl70";
-    libPath = "lib.rs";
-    features = mkFeatures (features."fnv"."1.0.7" or {});
-  };
-  features_.fnv."1.0.7" = deps: f: updateFeatures f (rec {
-    fnv = fold recursiveUpdate {} [
-      { "1.0.7"."std" =
-        (f.fnv."1.0.7"."std" or false) ||
-        (f.fnv."1.0.7".default or false) ||
-        (fnv."1.0.7"."default" or false); }
-      { "1.0.7".default = (f.fnv."1.0.7".default or true); }
-    ];
-  }) [];
 
 
 # end
@@ -1653,36 +1541,36 @@ rec {
 
 
 # end
-# libc-0.2.71
+# libc-0.2.86
 
-  crates.libc."0.2.71" = deps: { features?(features_.libc."0.2.71" deps {}) }: buildRustCrate {
+  crates.libc."0.2.86" = deps: { features?(features_.libc."0.2.86" deps {}) }: buildRustCrate {
     crateName = "libc";
-    version = "0.2.71";
+    version = "0.2.86";
     description = "Raw FFI bindings to platform libraries like libc.\n";
     authors = [ "The Rust Project Developers" ];
-    sha256 = "1j84p6skj6n2m9kjr8k20l07gi1pvraz4k6cl329qia5l4fg7qmz";
+    sha256 = "07w3fdl40mdizrcm8v3ysy9ar7x0rkp1wyihl4vvayanyhhzcqyk";
     build = "build.rs";
     dependencies = mapFeatures features ([
 ]);
-    features = mkFeatures (features."libc"."0.2.71" or {});
+    features = mkFeatures (features."libc"."0.2.86" or {});
   };
-  features_.libc."0.2.71" = deps: f: updateFeatures f (rec {
+  features_.libc."0.2.86" = deps: f: updateFeatures f (rec {
     libc = fold recursiveUpdate {} [
-      { "0.2.71"."align" =
-        (f.libc."0.2.71"."align" or false) ||
-        (f.libc."0.2.71".rustc-dep-of-std or false) ||
-        (libc."0.2.71"."rustc-dep-of-std" or false); }
-      { "0.2.71"."rustc-std-workspace-core" =
-        (f.libc."0.2.71"."rustc-std-workspace-core" or false) ||
-        (f.libc."0.2.71".rustc-dep-of-std or false) ||
-        (libc."0.2.71"."rustc-dep-of-std" or false); }
-      { "0.2.71"."std" =
-        (f.libc."0.2.71"."std" or false) ||
-        (f.libc."0.2.71".default or false) ||
-        (libc."0.2.71"."default" or false) ||
-        (f.libc."0.2.71".use_std or false) ||
-        (libc."0.2.71"."use_std" or false); }
-      { "0.2.71".default = (f.libc."0.2.71".default or true); }
+      { "0.2.86"."align" =
+        (f.libc."0.2.86"."align" or false) ||
+        (f.libc."0.2.86".rustc-dep-of-std or false) ||
+        (libc."0.2.86"."rustc-dep-of-std" or false); }
+      { "0.2.86"."rustc-std-workspace-core" =
+        (f.libc."0.2.86"."rustc-std-workspace-core" or false) ||
+        (f.libc."0.2.86".rustc-dep-of-std or false) ||
+        (libc."0.2.86"."rustc-dep-of-std" or false); }
+      { "0.2.86"."std" =
+        (f.libc."0.2.86"."std" or false) ||
+        (f.libc."0.2.86".default or false) ||
+        (libc."0.2.86"."default" or false) ||
+        (f.libc."0.2.86".use_std or false) ||
+        (libc."0.2.86"."use_std" or false); }
+      { "0.2.86".default = (f.libc."0.2.86".default or true); }
     ];
   }) [];
 
@@ -1732,17 +1620,24 @@ rec {
 
 
 # end
-# md5-0.6.1
+# md5-0.7.0
 
-  crates.md5."0.6.1" = deps: { features?(features_.md5."0.6.1" deps {}) }: buildRustCrate {
+  crates.md5."0.7.0" = deps: { features?(features_.md5."0.7.0" deps {}) }: buildRustCrate {
     crateName = "md5";
-    version = "0.6.1";
+    version = "0.7.0";
     description = "The package provides the MD5 hash function.";
-    authors = [ "Ivan Ukhov <ivan.ukhov@gmail.com>" "Kamal Ahmad <shibe@openmailbox.org>" "Konstantin Stepanov <milezv@gmail.com>" "Lukas Kalbertodt <lukas.kalbertodt@gmail.com>" "Nathan Musoke <nathan.musoke@gmail.com>" "Tony Arcieri <bascule@gmail.com>" "Wim de With <register@dewith.io>" "Yosef Dinerstein <yosefdi@gmail.com>" ];
-    sha256 = "0kkg05igb50l4v9c3dxd2mll548gkxqnj97sd2bnq3r433wa82d4";
+    authors = [ "Ivan Ukhov <ivan.ukhov@gmail.com>" "Kamal Ahmad <shibe@openmailbox.org>" "Konstantin Stepanov <milezv@gmail.com>" "Lukas Kalbertodt <lukas.kalbertodt@gmail.com>" "Nathan Musoke <nathan.musoke@gmail.com>" "Scott Mabin <scott@mabez.dev>" "Tony Arcieri <bascule@gmail.com>" "Wim de With <register@dewith.io>" "Yosef Dinerstein <yosefdi@gmail.com>" ];
+    sha256 = "0wm8p4xr40sgl0mdvqvs7w42s5v9jpaianmadkszsclmkmy8a5zc";
+    features = mkFeatures (features."md5"."0.7.0" or {});
   };
-  features_.md5."0.6.1" = deps: f: updateFeatures f (rec {
-    md5."0.6.1".default = (f.md5."0.6.1".default or true);
+  features_.md5."0.7.0" = deps: f: updateFeatures f (rec {
+    md5 = fold recursiveUpdate {} [
+      { "0.7.0"."std" =
+        (f.md5."0.7.0"."std" or false) ||
+        (f.md5."0.7.0".default or false) ||
+        (md5."0.7.0"."default" or false); }
+      { "0.7.0".default = (f.md5."0.7.0".default or true); }
+    ];
   }) [];
 
 
@@ -1979,19 +1874,19 @@ rec {
 
 
 # end
-# nix-0.17.0
+# nix-0.20.0
 
-  crates.nix."0.17.0" = deps: { features?(features_.nix."0.17.0" deps {}) }: buildRustCrate {
+  crates.nix."0.20.0" = deps: { features?(features_.nix."0.20.0" deps {}) }: buildRustCrate {
     crateName = "nix";
-    version = "0.17.0";
+    version = "0.20.0";
     description = "Rust friendly bindings to *nix APIs";
     authors = [ "The nix-rust Project Developers" ];
-    sha256 = "0zs4ywgv5vnnsp3bhbjs9d3as9z9flnpj914cx8qkgpzcsqcx9aw";
+    edition = "2018";
+    sha256 = "175h2nlkq2lpwyb8gqfivlkia53p9iqjgwpl5wsrf79fclh9p4mx";
     dependencies = mapFeatures features ([
-      (crates."bitflags"."${deps."nix"."0.17.0"."bitflags"}" deps)
-      (crates."cfg_if"."${deps."nix"."0.17.0"."cfg_if"}" deps)
-      (crates."libc"."${deps."nix"."0.17.0"."libc"}" deps)
-      (crates."void"."${deps."nix"."0.17.0"."void"}" deps)
+      (crates."bitflags"."${deps."nix"."0.20.0"."bitflags"}" deps)
+      (crates."cfg_if"."${deps."nix"."0.20.0"."cfg_if"}" deps)
+      (crates."libc"."${deps."nix"."0.20.0"."libc"}" deps)
     ])
       ++ (if kernel == "android" || kernel == "linux" then mapFeatures features ([
 ]) else [])
@@ -2000,20 +1895,18 @@ rec {
       ++ (if kernel == "freebsd" then mapFeatures features ([
 ]) else []);
   };
-  features_.nix."0.17.0" = deps: f: updateFeatures f (rec {
-    bitflags."${deps.nix."0.17.0".bitflags}".default = true;
-    cfg_if."${deps.nix."0.17.0".cfg_if}".default = true;
+  features_.nix."0.20.0" = deps: f: updateFeatures f (rec {
+    bitflags."${deps.nix."0.20.0".bitflags}".default = true;
+    cfg_if."${deps.nix."0.20.0".cfg_if}".default = true;
     libc = fold recursiveUpdate {} [
-      { "${deps.nix."0.17.0".libc}"."extra_traits" = true; }
-      { "${deps.nix."0.17.0".libc}".default = true; }
+      { "${deps.nix."0.20.0".libc}"."extra_traits" = true; }
+      { "${deps.nix."0.20.0".libc}".default = true; }
     ];
-    nix."0.17.0".default = (f.nix."0.17.0".default or true);
-    void."${deps.nix."0.17.0".void}".default = true;
+    nix."0.20.0".default = (f.nix."0.20.0".default or true);
   }) [
-    (features_.bitflags."${deps."nix"."0.17.0"."bitflags"}" deps)
-    (features_.cfg_if."${deps."nix"."0.17.0"."cfg_if"}" deps)
-    (features_.libc."${deps."nix"."0.17.0"."libc"}" deps)
-    (features_.void."${deps."nix"."0.17.0"."void"}" deps)
+    (features_.bitflags."${deps."nix"."0.20.0"."bitflags"}" deps)
+    (features_.cfg_if."${deps."nix"."0.20.0"."cfg_if"}" deps)
+    (features_.libc."${deps."nix"."0.20.0"."libc"}" deps)
   ];
 
 
@@ -2468,138 +2361,126 @@ rec {
 
 
 # end
-# proptest-0.9.6
+# proptest-0.10.1
 
-  crates.proptest."0.9.6" = deps: { features?(features_.proptest."0.9.6" deps {}) }: buildRustCrate {
+  crates.proptest."0.10.1" = deps: { features?(features_.proptest."0.10.1" deps {}) }: buildRustCrate {
     crateName = "proptest";
-    version = "0.9.6";
+    version = "0.10.1";
     description = "Hypothesis-like property-based testing and shrinking.\n";
     authors = [ "Jason Lingle" ];
     edition = "2018";
-    sha256 = "18dnj9pvb0bpcrclv71icfsqj0apx326dv4b0gp8cb72gipdxlbp";
+    sha256 = "05ssy0pkc17h7q210db6d9dxy3a2y3jk6qnnhpqlc30xvx3kdncz";
     dependencies = mapFeatures features ([
-      (crates."bitflags"."${deps."proptest"."0.9.6"."bitflags"}" deps)
-      (crates."byteorder"."${deps."proptest"."0.9.6"."byteorder"}" deps)
-      (crates."num_traits"."${deps."proptest"."0.9.6"."num_traits"}" deps)
-      (crates."rand"."${deps."proptest"."0.9.6"."rand"}" deps)
-      (crates."rand_chacha"."${deps."proptest"."0.9.6"."rand_chacha"}" deps)
-      (crates."rand_xorshift"."${deps."proptest"."0.9.6"."rand_xorshift"}" deps)
+      (crates."bitflags"."${deps."proptest"."0.10.1"."bitflags"}" deps)
+      (crates."byteorder"."${deps."proptest"."0.10.1"."byteorder"}" deps)
+      (crates."num_traits"."${deps."proptest"."0.10.1"."num_traits"}" deps)
+      (crates."rand"."${deps."proptest"."0.10.1"."rand"}" deps)
+      (crates."rand_chacha"."${deps."proptest"."0.10.1"."rand_chacha"}" deps)
+      (crates."rand_xorshift"."${deps."proptest"."0.10.1"."rand_xorshift"}" deps)
     ]
-      ++ (if features.proptest."0.9.6".bit-set or false then [ (crates.bit_set."${deps."proptest"."0.9.6".bit_set}" deps) ] else [])
-      ++ (if features.proptest."0.9.6".lazy_static or false then [ (crates.lazy_static."${deps."proptest"."0.9.6".lazy_static}" deps) ] else [])
-      ++ (if features.proptest."0.9.6".quick-error or false then [ (crates.quick_error."${deps."proptest"."0.9.6".quick_error}" deps) ] else [])
-      ++ (if features.proptest."0.9.6".regex-syntax or false then [ (crates.regex_syntax."${deps."proptest"."0.9.6".regex_syntax}" deps) ] else [])
-      ++ (if features.proptest."0.9.6".rusty-fork or false then [ (crates.rusty_fork."${deps."proptest"."0.9.6".rusty_fork}" deps) ] else [])
-      ++ (if features.proptest."0.9.6".tempfile or false then [ (crates.tempfile."${deps."proptest"."0.9.6".tempfile}" deps) ] else []));
-    features = mkFeatures (features."proptest"."0.9.6" or {});
+      ++ (if features.proptest."0.10.1".lazy_static or false then [ (crates.lazy_static."${deps."proptest"."0.10.1".lazy_static}" deps) ] else [])
+      ++ (if features.proptest."0.10.1".quick-error or false then [ (crates.quick_error."${deps."proptest"."0.10.1".quick_error}" deps) ] else [])
+      ++ (if features.proptest."0.10.1".regex-syntax or false then [ (crates.regex_syntax."${deps."proptest"."0.10.1".regex_syntax}" deps) ] else []));
+    features = mkFeatures (features."proptest"."0.10.1" or {});
   };
-  features_.proptest."0.9.6" = deps: f: updateFeatures f (rec {
-    bit_set."${deps.proptest."0.9.6".bit_set}".default = true;
-    bitflags."${deps.proptest."0.9.6".bitflags}".default = true;
+  features_.proptest."0.10.1" = deps: f: updateFeatures f (rec {
+    bitflags."${deps.proptest."0.10.1".bitflags}".default = true;
     byteorder = fold recursiveUpdate {} [
-      { "${deps.proptest."0.9.6".byteorder}"."std" =
-        (f.byteorder."${deps.proptest."0.9.6".byteorder}"."std" or false) ||
-        (proptest."0.9.6"."std" or false) ||
-        (f."proptest"."0.9.6"."std" or false); }
-      { "${deps.proptest."0.9.6".byteorder}".default = (f.byteorder."${deps.proptest."0.9.6".byteorder}".default or false); }
+      { "${deps.proptest."0.10.1".byteorder}"."std" =
+        (f.byteorder."${deps.proptest."0.10.1".byteorder}"."std" or false) ||
+        (proptest."0.10.1"."std" or false) ||
+        (f."proptest"."0.10.1"."std" or false); }
+      { "${deps.proptest."0.10.1".byteorder}".default = (f.byteorder."${deps.proptest."0.10.1".byteorder}".default or false); }
     ];
-    lazy_static."${deps.proptest."0.9.6".lazy_static}".default = true;
+    lazy_static."${deps.proptest."0.10.1".lazy_static}".default = true;
     num_traits = fold recursiveUpdate {} [
-      { "${deps.proptest."0.9.6".num_traits}"."std" =
-        (f.num_traits."${deps.proptest."0.9.6".num_traits}"."std" or false) ||
-        (proptest."0.9.6"."std" or false) ||
-        (f."proptest"."0.9.6"."std" or false); }
-      { "${deps.proptest."0.9.6".num_traits}".default = (f.num_traits."${deps.proptest."0.9.6".num_traits}".default or false); }
+      { "${deps.proptest."0.10.1".num_traits}"."std" =
+        (f.num_traits."${deps.proptest."0.10.1".num_traits}"."std" or false) ||
+        (proptest."0.10.1"."std" or false) ||
+        (f."proptest"."0.10.1"."std" or false); }
+      { "${deps.proptest."0.10.1".num_traits}".default = (f.num_traits."${deps.proptest."0.10.1".num_traits}".default or false); }
     ];
     proptest = fold recursiveUpdate {} [
-      { "0.9.6"."bit-set" =
-        (f.proptest."0.9.6"."bit-set" or false) ||
-        (f.proptest."0.9.6".default or false) ||
-        (proptest."0.9.6"."default" or false) ||
-        (f.proptest."0.9.6".default-code-coverage or false) ||
-        (proptest."0.9.6"."default-code-coverage" or false); }
-      { "0.9.6"."break-dead-code" =
-        (f.proptest."0.9.6"."break-dead-code" or false) ||
-        (f.proptest."0.9.6".default or false) ||
-        (proptest."0.9.6"."default" or false); }
-      { "0.9.6"."fork" =
-        (f.proptest."0.9.6"."fork" or false) ||
-        (f.proptest."0.9.6".default or false) ||
-        (proptest."0.9.6"."default" or false) ||
-        (f.proptest."0.9.6".default-code-coverage or false) ||
-        (proptest."0.9.6"."default-code-coverage" or false) ||
-        (f.proptest."0.9.6".timeout or false) ||
-        (proptest."0.9.6"."timeout" or false); }
-      { "0.9.6"."lazy_static" =
-        (f.proptest."0.9.6"."lazy_static" or false) ||
-        (f.proptest."0.9.6".std or false) ||
-        (proptest."0.9.6"."std" or false); }
-      { "0.9.6"."quick-error" =
-        (f.proptest."0.9.6"."quick-error" or false) ||
-        (f.proptest."0.9.6".std or false) ||
-        (proptest."0.9.6"."std" or false); }
-      { "0.9.6"."regex-syntax" =
-        (f.proptest."0.9.6"."regex-syntax" or false) ||
-        (f.proptest."0.9.6".std or false) ||
-        (proptest."0.9.6"."std" or false); }
-      { "0.9.6"."rusty-fork" =
-        (f.proptest."0.9.6"."rusty-fork" or false) ||
-        (f.proptest."0.9.6".fork or false) ||
-        (proptest."0.9.6"."fork" or false); }
-      { "0.9.6"."std" =
-        (f.proptest."0.9.6"."std" or false) ||
-        (f.proptest."0.9.6".default or false) ||
-        (proptest."0.9.6"."default" or false) ||
-        (f.proptest."0.9.6".default-code-coverage or false) ||
-        (proptest."0.9.6"."default-code-coverage" or false) ||
-        (f.proptest."0.9.6".fork or false) ||
-        (proptest."0.9.6"."fork" or false); }
-      { "0.9.6"."tempfile" =
-        (f.proptest."0.9.6"."tempfile" or false) ||
-        (f.proptest."0.9.6".fork or false) ||
-        (proptest."0.9.6"."fork" or false); }
-      { "0.9.6"."timeout" =
-        (f.proptest."0.9.6"."timeout" or false) ||
-        (f.proptest."0.9.6".default or false) ||
-        (proptest."0.9.6"."default" or false) ||
-        (f.proptest."0.9.6".default-code-coverage or false) ||
-        (proptest."0.9.6"."default-code-coverage" or false); }
-      { "0.9.6".default = (f.proptest."0.9.6".default or true); }
+      { "0.10.1"."bit-set" =
+        (f.proptest."0.10.1"."bit-set" or false) ||
+        (f.proptest."0.10.1".default or false) ||
+        (proptest."0.10.1"."default" or false) ||
+        (f.proptest."0.10.1".default-code-coverage or false) ||
+        (proptest."0.10.1"."default-code-coverage" or false); }
+      { "0.10.1"."break-dead-code" =
+        (f.proptest."0.10.1"."break-dead-code" or false) ||
+        (f.proptest."0.10.1".default or false) ||
+        (proptest."0.10.1"."default" or false); }
+      { "0.10.1"."fork" =
+        (f.proptest."0.10.1"."fork" or false) ||
+        (f.proptest."0.10.1".default or false) ||
+        (proptest."0.10.1"."default" or false) ||
+        (f.proptest."0.10.1".default-code-coverage or false) ||
+        (proptest."0.10.1"."default-code-coverage" or false) ||
+        (f.proptest."0.10.1".timeout or false) ||
+        (proptest."0.10.1"."timeout" or false); }
+      { "0.10.1"."lazy_static" =
+        (f.proptest."0.10.1"."lazy_static" or false) ||
+        (f.proptest."0.10.1".std or false) ||
+        (proptest."0.10.1"."std" or false); }
+      { "0.10.1"."quick-error" =
+        (f.proptest."0.10.1"."quick-error" or false) ||
+        (f.proptest."0.10.1".std or false) ||
+        (proptest."0.10.1"."std" or false); }
+      { "0.10.1"."regex-syntax" =
+        (f.proptest."0.10.1"."regex-syntax" or false) ||
+        (f.proptest."0.10.1".std or false) ||
+        (proptest."0.10.1"."std" or false); }
+      { "0.10.1"."rusty-fork" =
+        (f.proptest."0.10.1"."rusty-fork" or false) ||
+        (f.proptest."0.10.1".fork or false) ||
+        (proptest."0.10.1"."fork" or false); }
+      { "0.10.1"."std" =
+        (f.proptest."0.10.1"."std" or false) ||
+        (f.proptest."0.10.1".default or false) ||
+        (proptest."0.10.1"."default" or false) ||
+        (f.proptest."0.10.1".default-code-coverage or false) ||
+        (proptest."0.10.1"."default-code-coverage" or false) ||
+        (f.proptest."0.10.1".fork or false) ||
+        (proptest."0.10.1"."fork" or false); }
+      { "0.10.1"."tempfile" =
+        (f.proptest."0.10.1"."tempfile" or false) ||
+        (f.proptest."0.10.1".fork or false) ||
+        (proptest."0.10.1"."fork" or false); }
+      { "0.10.1"."timeout" =
+        (f.proptest."0.10.1"."timeout" or false) ||
+        (f.proptest."0.10.1".default or false) ||
+        (proptest."0.10.1"."default" or false) ||
+        (f.proptest."0.10.1".default-code-coverage or false) ||
+        (proptest."0.10.1"."default-code-coverage" or false); }
+      { "0.10.1"."x86" =
+        (f.proptest."0.10.1"."x86" or false) ||
+        (f.proptest."0.10.1".hardware-rng or false) ||
+        (proptest."0.10.1"."hardware-rng" or false); }
+      { "0.10.1".default = (f.proptest."0.10.1".default or true); }
     ];
-    quick_error."${deps.proptest."0.9.6".quick_error}".default = true;
+    quick_error."${deps.proptest."0.10.1".quick_error}".default = true;
     rand = fold recursiveUpdate {} [
-      { "${deps.proptest."0.9.6".rand}"."alloc" = true; }
-      { "${deps.proptest."0.9.6".rand}"."i128_support" = true; }
-      { "${deps.proptest."0.9.6".rand}"."std" =
-        (f.rand."${deps.proptest."0.9.6".rand}"."std" or false) ||
-        (proptest."0.9.6"."std" or false) ||
-        (f."proptest"."0.9.6"."std" or false); }
-      { "${deps.proptest."0.9.6".rand}".default = (f.rand."${deps.proptest."0.9.6".rand}".default or false); }
+      { "${deps.proptest."0.10.1".rand}"."alloc" = true; }
+      { "${deps.proptest."0.10.1".rand}"."std" =
+        (f.rand."${deps.proptest."0.10.1".rand}"."std" or false) ||
+        (proptest."0.10.1"."std" or false) ||
+        (f."proptest"."0.10.1"."std" or false); }
+      { "${deps.proptest."0.10.1".rand}".default = (f.rand."${deps.proptest."0.10.1".rand}".default or false); }
     ];
-    rand_chacha."${deps.proptest."0.9.6".rand_chacha}".default = true;
-    rand_xorshift."${deps.proptest."0.9.6".rand_xorshift}".default = true;
-    regex_syntax."${deps.proptest."0.9.6".regex_syntax}".default = true;
-    rusty_fork = fold recursiveUpdate {} [
-      { "${deps.proptest."0.9.6".rusty_fork}"."timeout" =
-        (f.rusty_fork."${deps.proptest."0.9.6".rusty_fork}"."timeout" or false) ||
-        (proptest."0.9.6"."timeout" or false) ||
-        (f."proptest"."0.9.6"."timeout" or false); }
-      { "${deps.proptest."0.9.6".rusty_fork}".default = (f.rusty_fork."${deps.proptest."0.9.6".rusty_fork}".default or false); }
-    ];
-    tempfile."${deps.proptest."0.9.6".tempfile}".default = true;
+    rand_chacha."${deps.proptest."0.10.1".rand_chacha}".default = (f.rand_chacha."${deps.proptest."0.10.1".rand_chacha}".default or false);
+    rand_xorshift."${deps.proptest."0.10.1".rand_xorshift}".default = true;
+    regex_syntax."${deps.proptest."0.10.1".regex_syntax}".default = true;
   }) [
-    (features_.bit_set."${deps."proptest"."0.9.6"."bit_set"}" deps)
-    (features_.bitflags."${deps."proptest"."0.9.6"."bitflags"}" deps)
-    (features_.byteorder."${deps."proptest"."0.9.6"."byteorder"}" deps)
-    (features_.lazy_static."${deps."proptest"."0.9.6"."lazy_static"}" deps)
-    (features_.num_traits."${deps."proptest"."0.9.6"."num_traits"}" deps)
-    (features_.quick_error."${deps."proptest"."0.9.6"."quick_error"}" deps)
-    (features_.rand."${deps."proptest"."0.9.6"."rand"}" deps)
-    (features_.rand_chacha."${deps."proptest"."0.9.6"."rand_chacha"}" deps)
-    (features_.rand_xorshift."${deps."proptest"."0.9.6"."rand_xorshift"}" deps)
-    (features_.regex_syntax."${deps."proptest"."0.9.6"."regex_syntax"}" deps)
-    (features_.rusty_fork."${deps."proptest"."0.9.6"."rusty_fork"}" deps)
-    (features_.tempfile."${deps."proptest"."0.9.6"."tempfile"}" deps)
+    (features_.bitflags."${deps."proptest"."0.10.1"."bitflags"}" deps)
+    (features_.byteorder."${deps."proptest"."0.10.1"."byteorder"}" deps)
+    (features_.lazy_static."${deps."proptest"."0.10.1"."lazy_static"}" deps)
+    (features_.num_traits."${deps."proptest"."0.10.1"."num_traits"}" deps)
+    (features_.quick_error."${deps."proptest"."0.10.1"."quick_error"}" deps)
+    (features_.rand."${deps."proptest"."0.10.1"."rand"}" deps)
+    (features_.rand_chacha."${deps."proptest"."0.10.1"."rand_chacha"}" deps)
+    (features_.rand_xorshift."${deps."proptest"."0.10.1"."rand_xorshift"}" deps)
+    (features_.regex_syntax."${deps."proptest"."0.10.1"."regex_syntax"}" deps)
   ];
 
 
@@ -2748,136 +2629,6 @@ rec {
 
 
 # end
-# rand-0.6.5
-
-  crates.rand."0.6.5" = deps: { features?(features_.rand."0.6.5" deps {}) }: buildRustCrate {
-    crateName = "rand";
-    version = "0.6.5";
-    description = "Random number generators and other randomness functionality.\n";
-    authors = [ "The Rand Project Developers" "The Rust Project Developers" ];
-    sha256 = "0zbck48159aj8zrwzf80sd9xxh96w4f4968nshwjpysjvflimvgb";
-    build = "build.rs";
-    dependencies = mapFeatures features ([
-      (crates."rand_chacha"."${deps."rand"."0.6.5"."rand_chacha"}" deps)
-      (crates."rand_core"."${deps."rand"."0.6.5"."rand_core"}" deps)
-      (crates."rand_hc"."${deps."rand"."0.6.5"."rand_hc"}" deps)
-      (crates."rand_isaac"."${deps."rand"."0.6.5"."rand_isaac"}" deps)
-      (crates."rand_jitter"."${deps."rand"."0.6.5"."rand_jitter"}" deps)
-      (crates."rand_pcg"."${deps."rand"."0.6.5"."rand_pcg"}" deps)
-      (crates."rand_xorshift"."${deps."rand"."0.6.5"."rand_xorshift"}" deps)
-    ]
-      ++ (if features.rand."0.6.5".rand_os or false then [ (crates.rand_os."${deps."rand"."0.6.5".rand_os}" deps) ] else []))
-      ++ (if (kernel == "linux" || kernel == "darwin") then mapFeatures features ([
-      (crates."libc"."${deps."rand"."0.6.5"."libc"}" deps)
-    ]) else [])
-      ++ (if kernel == "windows" then mapFeatures features ([
-      (crates."winapi"."${deps."rand"."0.6.5"."winapi"}" deps)
-    ]) else []);
-
-    buildDependencies = mapFeatures features ([
-      (crates."autocfg"."${deps."rand"."0.6.5"."autocfg"}" deps)
-    ]);
-    features = mkFeatures (features."rand"."0.6.5" or {});
-  };
-  features_.rand."0.6.5" = deps: f: updateFeatures f (rec {
-    autocfg."${deps.rand."0.6.5".autocfg}".default = true;
-    libc."${deps.rand."0.6.5".libc}".default = (f.libc."${deps.rand."0.6.5".libc}".default or false);
-    rand = fold recursiveUpdate {} [
-      { "0.6.5"."alloc" =
-        (f.rand."0.6.5"."alloc" or false) ||
-        (f.rand."0.6.5".std or false) ||
-        (rand."0.6.5"."std" or false); }
-      { "0.6.5"."packed_simd" =
-        (f.rand."0.6.5"."packed_simd" or false) ||
-        (f.rand."0.6.5".simd_support or false) ||
-        (rand."0.6.5"."simd_support" or false); }
-      { "0.6.5"."rand_os" =
-        (f.rand."0.6.5"."rand_os" or false) ||
-        (f.rand."0.6.5".std or false) ||
-        (rand."0.6.5"."std" or false); }
-      { "0.6.5"."simd_support" =
-        (f.rand."0.6.5"."simd_support" or false) ||
-        (f.rand."0.6.5".nightly or false) ||
-        (rand."0.6.5"."nightly" or false); }
-      { "0.6.5"."std" =
-        (f.rand."0.6.5"."std" or false) ||
-        (f.rand."0.6.5".default or false) ||
-        (rand."0.6.5"."default" or false); }
-      { "0.6.5".default = (f.rand."0.6.5".default or true); }
-    ];
-    rand_chacha."${deps.rand."0.6.5".rand_chacha}".default = true;
-    rand_core = fold recursiveUpdate {} [
-      { "${deps.rand."0.6.5".rand_core}"."alloc" =
-        (f.rand_core."${deps.rand."0.6.5".rand_core}"."alloc" or false) ||
-        (rand."0.6.5"."alloc" or false) ||
-        (f."rand"."0.6.5"."alloc" or false); }
-      { "${deps.rand."0.6.5".rand_core}"."serde1" =
-        (f.rand_core."${deps.rand."0.6.5".rand_core}"."serde1" or false) ||
-        (rand."0.6.5"."serde1" or false) ||
-        (f."rand"."0.6.5"."serde1" or false); }
-      { "${deps.rand."0.6.5".rand_core}"."std" =
-        (f.rand_core."${deps.rand."0.6.5".rand_core}"."std" or false) ||
-        (rand."0.6.5"."std" or false) ||
-        (f."rand"."0.6.5"."std" or false); }
-      { "${deps.rand."0.6.5".rand_core}".default = true; }
-    ];
-    rand_hc."${deps.rand."0.6.5".rand_hc}".default = true;
-    rand_isaac = fold recursiveUpdate {} [
-      { "${deps.rand."0.6.5".rand_isaac}"."serde1" =
-        (f.rand_isaac."${deps.rand."0.6.5".rand_isaac}"."serde1" or false) ||
-        (rand."0.6.5"."serde1" or false) ||
-        (f."rand"."0.6.5"."serde1" or false); }
-      { "${deps.rand."0.6.5".rand_isaac}".default = true; }
-    ];
-    rand_jitter = fold recursiveUpdate {} [
-      { "${deps.rand."0.6.5".rand_jitter}"."std" =
-        (f.rand_jitter."${deps.rand."0.6.5".rand_jitter}"."std" or false) ||
-        (rand."0.6.5"."std" or false) ||
-        (f."rand"."0.6.5"."std" or false); }
-      { "${deps.rand."0.6.5".rand_jitter}".default = true; }
-    ];
-    rand_os = fold recursiveUpdate {} [
-      { "${deps.rand."0.6.5".rand_os}"."stdweb" =
-        (f.rand_os."${deps.rand."0.6.5".rand_os}"."stdweb" or false) ||
-        (rand."0.6.5"."stdweb" or false) ||
-        (f."rand"."0.6.5"."stdweb" or false); }
-      { "${deps.rand."0.6.5".rand_os}"."wasm-bindgen" =
-        (f.rand_os."${deps.rand."0.6.5".rand_os}"."wasm-bindgen" or false) ||
-        (rand."0.6.5"."wasm-bindgen" or false) ||
-        (f."rand"."0.6.5"."wasm-bindgen" or false); }
-      { "${deps.rand."0.6.5".rand_os}".default = true; }
-    ];
-    rand_pcg."${deps.rand."0.6.5".rand_pcg}".default = true;
-    rand_xorshift = fold recursiveUpdate {} [
-      { "${deps.rand."0.6.5".rand_xorshift}"."serde1" =
-        (f.rand_xorshift."${deps.rand."0.6.5".rand_xorshift}"."serde1" or false) ||
-        (rand."0.6.5"."serde1" or false) ||
-        (f."rand"."0.6.5"."serde1" or false); }
-      { "${deps.rand."0.6.5".rand_xorshift}".default = true; }
-    ];
-    winapi = fold recursiveUpdate {} [
-      { "${deps.rand."0.6.5".winapi}"."minwindef" = true; }
-      { "${deps.rand."0.6.5".winapi}"."ntsecapi" = true; }
-      { "${deps.rand."0.6.5".winapi}"."profileapi" = true; }
-      { "${deps.rand."0.6.5".winapi}"."winnt" = true; }
-      { "${deps.rand."0.6.5".winapi}".default = true; }
-    ];
-  }) [
-    (features_.rand_chacha."${deps."rand"."0.6.5"."rand_chacha"}" deps)
-    (features_.rand_core."${deps."rand"."0.6.5"."rand_core"}" deps)
-    (features_.rand_hc."${deps."rand"."0.6.5"."rand_hc"}" deps)
-    (features_.rand_isaac."${deps."rand"."0.6.5"."rand_isaac"}" deps)
-    (features_.rand_jitter."${deps."rand"."0.6.5"."rand_jitter"}" deps)
-    (features_.rand_os."${deps."rand"."0.6.5"."rand_os"}" deps)
-    (features_.rand_pcg."${deps."rand"."0.6.5"."rand_pcg"}" deps)
-    (features_.rand_xorshift."${deps."rand"."0.6.5"."rand_xorshift"}" deps)
-    (features_.autocfg."${deps."rand"."0.6.5"."autocfg"}" deps)
-    (features_.libc."${deps."rand"."0.6.5"."libc"}" deps)
-    (features_.winapi."${deps."rand"."0.6.5"."winapi"}" deps)
-  ];
-
-
-# end
 # rand-0.7.3
 
   crates.rand."0.7.3" = deps: { features?(features_.rand."0.7.3" deps {}) }: buildRustCrate {
@@ -2960,34 +2711,6 @@ rec {
     (features_.rand_chacha."${deps."rand"."0.7.3"."rand_chacha"}" deps)
     (features_.rand_hc."${deps."rand"."0.7.3"."rand_hc"}" deps)
     (features_.libc."${deps."rand"."0.7.3"."libc"}" deps)
-  ];
-
-
-# end
-# rand_chacha-0.1.1
-
-  crates.rand_chacha."0.1.1" = deps: { features?(features_.rand_chacha."0.1.1" deps {}) }: buildRustCrate {
-    crateName = "rand_chacha";
-    version = "0.1.1";
-    description = "ChaCha random number generator\n";
-    authors = [ "The Rand Project Developers" "The Rust Project Developers" ];
-    sha256 = "0xnxm4mjd7wjnh18zxc1yickw58axbycp35ciraplqdfwn1gffwi";
-    build = "build.rs";
-    dependencies = mapFeatures features ([
-      (crates."rand_core"."${deps."rand_chacha"."0.1.1"."rand_core"}" deps)
-    ]);
-
-    buildDependencies = mapFeatures features ([
-      (crates."autocfg"."${deps."rand_chacha"."0.1.1"."autocfg"}" deps)
-    ]);
-  };
-  features_.rand_chacha."0.1.1" = deps: f: updateFeatures f (rec {
-    autocfg."${deps.rand_chacha."0.1.1".autocfg}".default = true;
-    rand_chacha."0.1.1".default = (f.rand_chacha."0.1.1".default or true);
-    rand_core."${deps.rand_chacha."0.1.1".rand_core}".default = (f.rand_core."${deps.rand_chacha."0.1.1".rand_core}".default or false);
-  }) [
-    (features_.rand_core."${deps."rand_chacha"."0.1.1"."rand_core"}" deps)
-    (features_.autocfg."${deps."rand_chacha"."0.1.1"."autocfg"}" deps)
   ];
 
 
@@ -3150,27 +2873,6 @@ rec {
 
 
 # end
-# rand_hc-0.1.0
-
-  crates.rand_hc."0.1.0" = deps: { features?(features_.rand_hc."0.1.0" deps {}) }: buildRustCrate {
-    crateName = "rand_hc";
-    version = "0.1.0";
-    description = "HC128 random number generator\n";
-    authors = [ "The Rand Project Developers" ];
-    sha256 = "05agb75j87yp7y1zk8yf7bpm66hc0673r3dlypn0kazynr6fdgkz";
-    dependencies = mapFeatures features ([
-      (crates."rand_core"."${deps."rand_hc"."0.1.0"."rand_core"}" deps)
-    ]);
-  };
-  features_.rand_hc."0.1.0" = deps: f: updateFeatures f (rec {
-    rand_core."${deps.rand_hc."0.1.0".rand_core}".default = (f.rand_core."${deps.rand_hc."0.1.0".rand_core}".default or false);
-    rand_hc."0.1.0".default = (f.rand_hc."0.1.0".default or true);
-  }) [
-    (features_.rand_core."${deps."rand_hc"."0.1.0"."rand_core"}" deps)
-  ];
-
-
-# end
 # rand_hc-0.2.0
 
   crates.rand_hc."0.2.0" = deps: { features?(features_.rand_hc."0.2.0" deps {}) }: buildRustCrate {
@@ -3193,208 +2895,31 @@ rec {
 
 
 # end
-# rand_isaac-0.1.1
+# rand_xorshift-0.2.0
 
-  crates.rand_isaac."0.1.1" = deps: { features?(features_.rand_isaac."0.1.1" deps {}) }: buildRustCrate {
-    crateName = "rand_isaac";
-    version = "0.1.1";
-    description = "ISAAC random number generator\n";
-    authors = [ "The Rand Project Developers" "The Rust Project Developers" ];
-    sha256 = "10hhdh5b5sa03s6b63y9bafm956jwilx41s71jbrzl63ccx8lxdq";
-    dependencies = mapFeatures features ([
-      (crates."rand_core"."${deps."rand_isaac"."0.1.1"."rand_core"}" deps)
-    ]);
-    features = mkFeatures (features."rand_isaac"."0.1.1" or {});
-  };
-  features_.rand_isaac."0.1.1" = deps: f: updateFeatures f (rec {
-    rand_core = fold recursiveUpdate {} [
-      { "${deps.rand_isaac."0.1.1".rand_core}"."serde1" =
-        (f.rand_core."${deps.rand_isaac."0.1.1".rand_core}"."serde1" or false) ||
-        (rand_isaac."0.1.1"."serde1" or false) ||
-        (f."rand_isaac"."0.1.1"."serde1" or false); }
-      { "${deps.rand_isaac."0.1.1".rand_core}".default = (f.rand_core."${deps.rand_isaac."0.1.1".rand_core}".default or false); }
-    ];
-    rand_isaac = fold recursiveUpdate {} [
-      { "0.1.1"."serde" =
-        (f.rand_isaac."0.1.1"."serde" or false) ||
-        (f.rand_isaac."0.1.1".serde1 or false) ||
-        (rand_isaac."0.1.1"."serde1" or false); }
-      { "0.1.1"."serde_derive" =
-        (f.rand_isaac."0.1.1"."serde_derive" or false) ||
-        (f.rand_isaac."0.1.1".serde1 or false) ||
-        (rand_isaac."0.1.1"."serde1" or false); }
-      { "0.1.1".default = (f.rand_isaac."0.1.1".default or true); }
-    ];
-  }) [
-    (features_.rand_core."${deps."rand_isaac"."0.1.1"."rand_core"}" deps)
-  ];
-
-
-# end
-# rand_jitter-0.1.4
-
-  crates.rand_jitter."0.1.4" = deps: { features?(features_.rand_jitter."0.1.4" deps {}) }: buildRustCrate {
-    crateName = "rand_jitter";
-    version = "0.1.4";
-    description = "Random number generator based on timing jitter";
-    authors = [ "The Rand Project Developers" ];
-    sha256 = "13nr4h042ab9l7qcv47bxrxw3gkf2pc3cni6c9pyi4nxla0mm7b6";
-    dependencies = mapFeatures features ([
-      (crates."rand_core"."${deps."rand_jitter"."0.1.4"."rand_core"}" deps)
-    ])
-      ++ (if kernel == "darwin" || kernel == "ios" then mapFeatures features ([
-      (crates."libc"."${deps."rand_jitter"."0.1.4"."libc"}" deps)
-    ]) else [])
-      ++ (if kernel == "windows" then mapFeatures features ([
-      (crates."winapi"."${deps."rand_jitter"."0.1.4"."winapi"}" deps)
-    ]) else []);
-    features = mkFeatures (features."rand_jitter"."0.1.4" or {});
-  };
-  features_.rand_jitter."0.1.4" = deps: f: updateFeatures f (rec {
-    libc."${deps.rand_jitter."0.1.4".libc}".default = true;
-    rand_core = fold recursiveUpdate {} [
-      { "${deps.rand_jitter."0.1.4".rand_core}"."std" =
-        (f.rand_core."${deps.rand_jitter."0.1.4".rand_core}"."std" or false) ||
-        (rand_jitter."0.1.4"."std" or false) ||
-        (f."rand_jitter"."0.1.4"."std" or false); }
-      { "${deps.rand_jitter."0.1.4".rand_core}".default = true; }
-    ];
-    rand_jitter."0.1.4".default = (f.rand_jitter."0.1.4".default or true);
-    winapi = fold recursiveUpdate {} [
-      { "${deps.rand_jitter."0.1.4".winapi}"."profileapi" = true; }
-      { "${deps.rand_jitter."0.1.4".winapi}".default = true; }
-    ];
-  }) [
-    (features_.rand_core."${deps."rand_jitter"."0.1.4"."rand_core"}" deps)
-    (features_.libc."${deps."rand_jitter"."0.1.4"."libc"}" deps)
-    (features_.winapi."${deps."rand_jitter"."0.1.4"."winapi"}" deps)
-  ];
-
-
-# end
-# rand_os-0.1.3
-
-  crates.rand_os."0.1.3" = deps: { features?(features_.rand_os."0.1.3" deps {}) }: buildRustCrate {
-    crateName = "rand_os";
-    version = "0.1.3";
-    description = "OS backed Random Number Generator";
-    authors = [ "The Rand Project Developers" ];
-    sha256 = "0ywwspizgs9g8vzn6m5ix9yg36n15119d6n792h7mk4r5vs0ww4j";
-    dependencies = mapFeatures features ([
-      (crates."rand_core"."${deps."rand_os"."0.1.3"."rand_core"}" deps)
-    ])
-      ++ (if abi == "sgx" then mapFeatures features ([
-      (crates."rdrand"."${deps."rand_os"."0.1.3"."rdrand"}" deps)
-    ]) else [])
-      ++ (if kernel == "cloudabi" then mapFeatures features ([
-      (crates."cloudabi"."${deps."rand_os"."0.1.3"."cloudabi"}" deps)
-    ]) else [])
-      ++ (if kernel == "fuchsia" then mapFeatures features ([
-      (crates."fuchsia_cprng"."${deps."rand_os"."0.1.3"."fuchsia_cprng"}" deps)
-    ]) else [])
-      ++ (if (kernel == "linux" || kernel == "darwin") then mapFeatures features ([
-      (crates."libc"."${deps."rand_os"."0.1.3"."libc"}" deps)
-    ]) else [])
-      ++ (if kernel == "windows" then mapFeatures features ([
-      (crates."winapi"."${deps."rand_os"."0.1.3"."winapi"}" deps)
-    ]) else [])
-      ++ (if kernel == "wasm32-unknown-unknown" then mapFeatures features ([
-]) else []);
-  };
-  features_.rand_os."0.1.3" = deps: f: updateFeatures f (rec {
-    cloudabi."${deps.rand_os."0.1.3".cloudabi}".default = true;
-    fuchsia_cprng."${deps.rand_os."0.1.3".fuchsia_cprng}".default = true;
-    libc."${deps.rand_os."0.1.3".libc}".default = true;
-    rand_core = fold recursiveUpdate {} [
-      { "${deps.rand_os."0.1.3".rand_core}"."std" = true; }
-      { "${deps.rand_os."0.1.3".rand_core}".default = true; }
-    ];
-    rand_os."0.1.3".default = (f.rand_os."0.1.3".default or true);
-    rdrand."${deps.rand_os."0.1.3".rdrand}".default = true;
-    winapi = fold recursiveUpdate {} [
-      { "${deps.rand_os."0.1.3".winapi}"."minwindef" = true; }
-      { "${deps.rand_os."0.1.3".winapi}"."ntsecapi" = true; }
-      { "${deps.rand_os."0.1.3".winapi}"."winnt" = true; }
-      { "${deps.rand_os."0.1.3".winapi}".default = true; }
-    ];
-  }) [
-    (features_.rand_core."${deps."rand_os"."0.1.3"."rand_core"}" deps)
-    (features_.rdrand."${deps."rand_os"."0.1.3"."rdrand"}" deps)
-    (features_.cloudabi."${deps."rand_os"."0.1.3"."cloudabi"}" deps)
-    (features_.fuchsia_cprng."${deps."rand_os"."0.1.3"."fuchsia_cprng"}" deps)
-    (features_.libc."${deps."rand_os"."0.1.3"."libc"}" deps)
-    (features_.winapi."${deps."rand_os"."0.1.3"."winapi"}" deps)
-  ];
-
-
-# end
-# rand_pcg-0.1.2
-
-  crates.rand_pcg."0.1.2" = deps: { features?(features_.rand_pcg."0.1.2" deps {}) }: buildRustCrate {
-    crateName = "rand_pcg";
-    version = "0.1.2";
-    description = "Selected PCG random number generators\n";
-    authors = [ "The Rand Project Developers" ];
-    sha256 = "04qgi2ai2z42li5h4aawvxbpnlqyjfnipz9d6k73mdnl6p1xq938";
-    build = "build.rs";
-    dependencies = mapFeatures features ([
-      (crates."rand_core"."${deps."rand_pcg"."0.1.2"."rand_core"}" deps)
-    ]);
-
-    buildDependencies = mapFeatures features ([
-      (crates."autocfg"."${deps."rand_pcg"."0.1.2"."autocfg"}" deps)
-    ]);
-    features = mkFeatures (features."rand_pcg"."0.1.2" or {});
-  };
-  features_.rand_pcg."0.1.2" = deps: f: updateFeatures f (rec {
-    autocfg."${deps.rand_pcg."0.1.2".autocfg}".default = true;
-    rand_core."${deps.rand_pcg."0.1.2".rand_core}".default = true;
-    rand_pcg = fold recursiveUpdate {} [
-      { "0.1.2"."serde" =
-        (f.rand_pcg."0.1.2"."serde" or false) ||
-        (f.rand_pcg."0.1.2".serde1 or false) ||
-        (rand_pcg."0.1.2"."serde1" or false); }
-      { "0.1.2"."serde_derive" =
-        (f.rand_pcg."0.1.2"."serde_derive" or false) ||
-        (f.rand_pcg."0.1.2".serde1 or false) ||
-        (rand_pcg."0.1.2"."serde1" or false); }
-      { "0.1.2".default = (f.rand_pcg."0.1.2".default or true); }
-    ];
-  }) [
-    (features_.rand_core."${deps."rand_pcg"."0.1.2"."rand_core"}" deps)
-    (features_.autocfg."${deps."rand_pcg"."0.1.2"."autocfg"}" deps)
-  ];
-
-
-# end
-# rand_xorshift-0.1.1
-
-  crates.rand_xorshift."0.1.1" = deps: { features?(features_.rand_xorshift."0.1.1" deps {}) }: buildRustCrate {
+  crates.rand_xorshift."0.2.0" = deps: { features?(features_.rand_xorshift."0.2.0" deps {}) }: buildRustCrate {
     crateName = "rand_xorshift";
-    version = "0.1.1";
+    version = "0.2.0";
     description = "Xorshift random number generator\n";
     authors = [ "The Rand Project Developers" "The Rust Project Developers" ];
-    sha256 = "0v365c4h4lzxwz5k5kp9m0661s0sss7ylv74if0xb4svis9sswnn";
+    edition = "2018";
+    sha256 = "14lj3xzbaxc5sh7kn0jlcbik1dp2jw8dyp6xwjdi1y9jgia07ww3";
     dependencies = mapFeatures features ([
-      (crates."rand_core"."${deps."rand_xorshift"."0.1.1"."rand_core"}" deps)
+      (crates."rand_core"."${deps."rand_xorshift"."0.2.0"."rand_core"}" deps)
     ]);
-    features = mkFeatures (features."rand_xorshift"."0.1.1" or {});
+    features = mkFeatures (features."rand_xorshift"."0.2.0" or {});
   };
-  features_.rand_xorshift."0.1.1" = deps: f: updateFeatures f (rec {
-    rand_core."${deps.rand_xorshift."0.1.1".rand_core}".default = (f.rand_core."${deps.rand_xorshift."0.1.1".rand_core}".default or false);
+  features_.rand_xorshift."0.2.0" = deps: f: updateFeatures f (rec {
+    rand_core."${deps.rand_xorshift."0.2.0".rand_core}".default = true;
     rand_xorshift = fold recursiveUpdate {} [
-      { "0.1.1"."serde" =
-        (f.rand_xorshift."0.1.1"."serde" or false) ||
-        (f.rand_xorshift."0.1.1".serde1 or false) ||
-        (rand_xorshift."0.1.1"."serde1" or false); }
-      { "0.1.1"."serde_derive" =
-        (f.rand_xorshift."0.1.1"."serde_derive" or false) ||
-        (f.rand_xorshift."0.1.1".serde1 or false) ||
-        (rand_xorshift."0.1.1"."serde1" or false); }
-      { "0.1.1".default = (f.rand_xorshift."0.1.1".default or true); }
+      { "0.2.0"."serde" =
+        (f.rand_xorshift."0.2.0"."serde" or false) ||
+        (f.rand_xorshift."0.2.0".serde1 or false) ||
+        (rand_xorshift."0.2.0"."serde1" or false); }
+      { "0.2.0".default = (f.rand_xorshift."0.2.0".default or true); }
     ];
   }) [
-    (features_.rand_core."${deps."rand_xorshift"."0.1.1"."rand_core"}" deps)
+    (features_.rand_core."${deps."rand_xorshift"."0.2.0"."rand_core"}" deps)
   ];
 
 
@@ -3470,196 +2995,196 @@ rec {
 
 
 # end
-# regex-1.3.9
+# regex-1.4.3
 
-  crates.regex."1.3.9" = deps: { features?(features_.regex."1.3.9" deps {}) }: buildRustCrate {
+  crates.regex."1.4.3" = deps: { features?(features_.regex."1.4.3" deps {}) }: buildRustCrate {
     crateName = "regex";
-    version = "1.3.9";
+    version = "1.4.3";
     description = "An implementation of regular expressions for Rust. This implementation uses\nfinite automata and guarantees linear time matching on all inputs.\n";
     authors = [ "The Rust Project Developers" ];
-    sha256 = "14x6jp4rmi5j5vfbvh8pl6l5sw7141brci6zksh6ljs2ihqcl290";
+    sha256 = "0w0b4bh0ng20lf5y8raaxmxj46ikjqpgwy1iggzpby9lhv9vydkp";
     dependencies = mapFeatures features ([
-      (crates."regex_syntax"."${deps."regex"."1.3.9"."regex_syntax"}" deps)
+      (crates."regex_syntax"."${deps."regex"."1.4.3"."regex_syntax"}" deps)
     ]
-      ++ (if features.regex."1.3.9".aho-corasick or false then [ (crates.aho_corasick."${deps."regex"."1.3.9".aho_corasick}" deps) ] else [])
-      ++ (if features.regex."1.3.9".memchr or false then [ (crates.memchr."${deps."regex"."1.3.9".memchr}" deps) ] else [])
-      ++ (if features.regex."1.3.9".thread_local or false then [ (crates.thread_local."${deps."regex"."1.3.9".thread_local}" deps) ] else []));
-    features = mkFeatures (features."regex"."1.3.9" or {});
+      ++ (if features.regex."1.4.3".aho-corasick or false then [ (crates.aho_corasick."${deps."regex"."1.4.3".aho_corasick}" deps) ] else [])
+      ++ (if features.regex."1.4.3".memchr or false then [ (crates.memchr."${deps."regex"."1.4.3".memchr}" deps) ] else [])
+      ++ (if features.regex."1.4.3".thread_local or false then [ (crates.thread_local."${deps."regex"."1.4.3".thread_local}" deps) ] else []));
+    features = mkFeatures (features."regex"."1.4.3" or {});
   };
-  features_.regex."1.3.9" = deps: f: updateFeatures f (rec {
-    aho_corasick."${deps.regex."1.3.9".aho_corasick}".default = true;
-    memchr."${deps.regex."1.3.9".memchr}".default = true;
+  features_.regex."1.4.3" = deps: f: updateFeatures f (rec {
+    aho_corasick."${deps.regex."1.4.3".aho_corasick}".default = true;
+    memchr."${deps.regex."1.4.3".memchr}".default = true;
     regex = fold recursiveUpdate {} [
-      { "1.3.9"."aho-corasick" =
-        (f.regex."1.3.9"."aho-corasick" or false) ||
-        (f.regex."1.3.9".perf-literal or false) ||
-        (regex."1.3.9"."perf-literal" or false); }
-      { "1.3.9"."memchr" =
-        (f.regex."1.3.9"."memchr" or false) ||
-        (f.regex."1.3.9".perf-literal or false) ||
-        (regex."1.3.9"."perf-literal" or false); }
-      { "1.3.9"."pattern" =
-        (f.regex."1.3.9"."pattern" or false) ||
-        (f.regex."1.3.9".unstable or false) ||
-        (regex."1.3.9"."unstable" or false); }
-      { "1.3.9"."perf" =
-        (f.regex."1.3.9"."perf" or false) ||
-        (f.regex."1.3.9".default or false) ||
-        (regex."1.3.9"."default" or false); }
-      { "1.3.9"."perf-cache" =
-        (f.regex."1.3.9"."perf-cache" or false) ||
-        (f.regex."1.3.9".perf or false) ||
-        (regex."1.3.9"."perf" or false); }
-      { "1.3.9"."perf-dfa" =
-        (f.regex."1.3.9"."perf-dfa" or false) ||
-        (f.regex."1.3.9".perf or false) ||
-        (regex."1.3.9"."perf" or false); }
-      { "1.3.9"."perf-inline" =
-        (f.regex."1.3.9"."perf-inline" or false) ||
-        (f.regex."1.3.9".perf or false) ||
-        (regex."1.3.9"."perf" or false); }
-      { "1.3.9"."perf-literal" =
-        (f.regex."1.3.9"."perf-literal" or false) ||
-        (f.regex."1.3.9".perf or false) ||
-        (regex."1.3.9"."perf" or false); }
-      { "1.3.9"."std" =
-        (f.regex."1.3.9"."std" or false) ||
-        (f.regex."1.3.9".default or false) ||
-        (regex."1.3.9"."default" or false) ||
-        (f.regex."1.3.9".use_std or false) ||
-        (regex."1.3.9"."use_std" or false); }
-      { "1.3.9"."thread_local" =
-        (f.regex."1.3.9"."thread_local" or false) ||
-        (f.regex."1.3.9".perf-cache or false) ||
-        (regex."1.3.9"."perf-cache" or false); }
-      { "1.3.9"."unicode" =
-        (f.regex."1.3.9"."unicode" or false) ||
-        (f.regex."1.3.9".default or false) ||
-        (regex."1.3.9"."default" or false); }
-      { "1.3.9"."unicode-age" =
-        (f.regex."1.3.9"."unicode-age" or false) ||
-        (f.regex."1.3.9".unicode or false) ||
-        (regex."1.3.9"."unicode" or false); }
-      { "1.3.9"."unicode-bool" =
-        (f.regex."1.3.9"."unicode-bool" or false) ||
-        (f.regex."1.3.9".unicode or false) ||
-        (regex."1.3.9"."unicode" or false); }
-      { "1.3.9"."unicode-case" =
-        (f.regex."1.3.9"."unicode-case" or false) ||
-        (f.regex."1.3.9".unicode or false) ||
-        (regex."1.3.9"."unicode" or false); }
-      { "1.3.9"."unicode-gencat" =
-        (f.regex."1.3.9"."unicode-gencat" or false) ||
-        (f.regex."1.3.9".unicode or false) ||
-        (regex."1.3.9"."unicode" or false); }
-      { "1.3.9"."unicode-perl" =
-        (f.regex."1.3.9"."unicode-perl" or false) ||
-        (f.regex."1.3.9".unicode or false) ||
-        (regex."1.3.9"."unicode" or false); }
-      { "1.3.9"."unicode-script" =
-        (f.regex."1.3.9"."unicode-script" or false) ||
-        (f.regex."1.3.9".unicode or false) ||
-        (regex."1.3.9"."unicode" or false); }
-      { "1.3.9"."unicode-segment" =
-        (f.regex."1.3.9"."unicode-segment" or false) ||
-        (f.regex."1.3.9".unicode or false) ||
-        (regex."1.3.9"."unicode" or false); }
-      { "1.3.9".default = (f.regex."1.3.9".default or true); }
+      { "1.4.3"."aho-corasick" =
+        (f.regex."1.4.3"."aho-corasick" or false) ||
+        (f.regex."1.4.3".perf-literal or false) ||
+        (regex."1.4.3"."perf-literal" or false); }
+      { "1.4.3"."memchr" =
+        (f.regex."1.4.3"."memchr" or false) ||
+        (f.regex."1.4.3".perf-literal or false) ||
+        (regex."1.4.3"."perf-literal" or false); }
+      { "1.4.3"."pattern" =
+        (f.regex."1.4.3"."pattern" or false) ||
+        (f.regex."1.4.3".unstable or false) ||
+        (regex."1.4.3"."unstable" or false); }
+      { "1.4.3"."perf" =
+        (f.regex."1.4.3"."perf" or false) ||
+        (f.regex."1.4.3".default or false) ||
+        (regex."1.4.3"."default" or false); }
+      { "1.4.3"."perf-cache" =
+        (f.regex."1.4.3"."perf-cache" or false) ||
+        (f.regex."1.4.3".perf or false) ||
+        (regex."1.4.3"."perf" or false); }
+      { "1.4.3"."perf-dfa" =
+        (f.regex."1.4.3"."perf-dfa" or false) ||
+        (f.regex."1.4.3".perf or false) ||
+        (regex."1.4.3"."perf" or false); }
+      { "1.4.3"."perf-inline" =
+        (f.regex."1.4.3"."perf-inline" or false) ||
+        (f.regex."1.4.3".perf or false) ||
+        (regex."1.4.3"."perf" or false); }
+      { "1.4.3"."perf-literal" =
+        (f.regex."1.4.3"."perf-literal" or false) ||
+        (f.regex."1.4.3".perf or false) ||
+        (regex."1.4.3"."perf" or false); }
+      { "1.4.3"."std" =
+        (f.regex."1.4.3"."std" or false) ||
+        (f.regex."1.4.3".default or false) ||
+        (regex."1.4.3"."default" or false) ||
+        (f.regex."1.4.3".use_std or false) ||
+        (regex."1.4.3"."use_std" or false); }
+      { "1.4.3"."thread_local" =
+        (f.regex."1.4.3"."thread_local" or false) ||
+        (f.regex."1.4.3".perf-cache or false) ||
+        (regex."1.4.3"."perf-cache" or false); }
+      { "1.4.3"."unicode" =
+        (f.regex."1.4.3"."unicode" or false) ||
+        (f.regex."1.4.3".default or false) ||
+        (regex."1.4.3"."default" or false); }
+      { "1.4.3"."unicode-age" =
+        (f.regex."1.4.3"."unicode-age" or false) ||
+        (f.regex."1.4.3".unicode or false) ||
+        (regex."1.4.3"."unicode" or false); }
+      { "1.4.3"."unicode-bool" =
+        (f.regex."1.4.3"."unicode-bool" or false) ||
+        (f.regex."1.4.3".unicode or false) ||
+        (regex."1.4.3"."unicode" or false); }
+      { "1.4.3"."unicode-case" =
+        (f.regex."1.4.3"."unicode-case" or false) ||
+        (f.regex."1.4.3".unicode or false) ||
+        (regex."1.4.3"."unicode" or false); }
+      { "1.4.3"."unicode-gencat" =
+        (f.regex."1.4.3"."unicode-gencat" or false) ||
+        (f.regex."1.4.3".unicode or false) ||
+        (regex."1.4.3"."unicode" or false); }
+      { "1.4.3"."unicode-perl" =
+        (f.regex."1.4.3"."unicode-perl" or false) ||
+        (f.regex."1.4.3".unicode or false) ||
+        (regex."1.4.3"."unicode" or false); }
+      { "1.4.3"."unicode-script" =
+        (f.regex."1.4.3"."unicode-script" or false) ||
+        (f.regex."1.4.3".unicode or false) ||
+        (regex."1.4.3"."unicode" or false); }
+      { "1.4.3"."unicode-segment" =
+        (f.regex."1.4.3"."unicode-segment" or false) ||
+        (f.regex."1.4.3".unicode or false) ||
+        (regex."1.4.3"."unicode" or false); }
+      { "1.4.3".default = (f.regex."1.4.3".default or true); }
     ];
     regex_syntax = fold recursiveUpdate {} [
-      { "${deps.regex."1.3.9".regex_syntax}"."default" =
-        (f.regex_syntax."${deps.regex."1.3.9".regex_syntax}"."default" or false) ||
-        (regex."1.3.9"."default" or false) ||
-        (f."regex"."1.3.9"."default" or false); }
-      { "${deps.regex."1.3.9".regex_syntax}"."unicode" =
-        (f.regex_syntax."${deps.regex."1.3.9".regex_syntax}"."unicode" or false) ||
-        (regex."1.3.9"."unicode" or false) ||
-        (f."regex"."1.3.9"."unicode" or false); }
-      { "${deps.regex."1.3.9".regex_syntax}"."unicode-age" =
-        (f.regex_syntax."${deps.regex."1.3.9".regex_syntax}"."unicode-age" or false) ||
-        (regex."1.3.9"."unicode-age" or false) ||
-        (f."regex"."1.3.9"."unicode-age" or false); }
-      { "${deps.regex."1.3.9".regex_syntax}"."unicode-bool" =
-        (f.regex_syntax."${deps.regex."1.3.9".regex_syntax}"."unicode-bool" or false) ||
-        (regex."1.3.9"."unicode-bool" or false) ||
-        (f."regex"."1.3.9"."unicode-bool" or false); }
-      { "${deps.regex."1.3.9".regex_syntax}"."unicode-case" =
-        (f.regex_syntax."${deps.regex."1.3.9".regex_syntax}"."unicode-case" or false) ||
-        (regex."1.3.9"."unicode-case" or false) ||
-        (f."regex"."1.3.9"."unicode-case" or false); }
-      { "${deps.regex."1.3.9".regex_syntax}"."unicode-gencat" =
-        (f.regex_syntax."${deps.regex."1.3.9".regex_syntax}"."unicode-gencat" or false) ||
-        (regex."1.3.9"."unicode-gencat" or false) ||
-        (f."regex"."1.3.9"."unicode-gencat" or false); }
-      { "${deps.regex."1.3.9".regex_syntax}"."unicode-perl" =
-        (f.regex_syntax."${deps.regex."1.3.9".regex_syntax}"."unicode-perl" or false) ||
-        (regex."1.3.9"."unicode-perl" or false) ||
-        (f."regex"."1.3.9"."unicode-perl" or false); }
-      { "${deps.regex."1.3.9".regex_syntax}"."unicode-script" =
-        (f.regex_syntax."${deps.regex."1.3.9".regex_syntax}"."unicode-script" or false) ||
-        (regex."1.3.9"."unicode-script" or false) ||
-        (f."regex"."1.3.9"."unicode-script" or false); }
-      { "${deps.regex."1.3.9".regex_syntax}"."unicode-segment" =
-        (f.regex_syntax."${deps.regex."1.3.9".regex_syntax}"."unicode-segment" or false) ||
-        (regex."1.3.9"."unicode-segment" or false) ||
-        (f."regex"."1.3.9"."unicode-segment" or false); }
-      { "${deps.regex."1.3.9".regex_syntax}".default = (f.regex_syntax."${deps.regex."1.3.9".regex_syntax}".default or false); }
+      { "${deps.regex."1.4.3".regex_syntax}"."default" =
+        (f.regex_syntax."${deps.regex."1.4.3".regex_syntax}"."default" or false) ||
+        (regex."1.4.3"."default" or false) ||
+        (f."regex"."1.4.3"."default" or false); }
+      { "${deps.regex."1.4.3".regex_syntax}"."unicode" =
+        (f.regex_syntax."${deps.regex."1.4.3".regex_syntax}"."unicode" or false) ||
+        (regex."1.4.3"."unicode" or false) ||
+        (f."regex"."1.4.3"."unicode" or false); }
+      { "${deps.regex."1.4.3".regex_syntax}"."unicode-age" =
+        (f.regex_syntax."${deps.regex."1.4.3".regex_syntax}"."unicode-age" or false) ||
+        (regex."1.4.3"."unicode-age" or false) ||
+        (f."regex"."1.4.3"."unicode-age" or false); }
+      { "${deps.regex."1.4.3".regex_syntax}"."unicode-bool" =
+        (f.regex_syntax."${deps.regex."1.4.3".regex_syntax}"."unicode-bool" or false) ||
+        (regex."1.4.3"."unicode-bool" or false) ||
+        (f."regex"."1.4.3"."unicode-bool" or false); }
+      { "${deps.regex."1.4.3".regex_syntax}"."unicode-case" =
+        (f.regex_syntax."${deps.regex."1.4.3".regex_syntax}"."unicode-case" or false) ||
+        (regex."1.4.3"."unicode-case" or false) ||
+        (f."regex"."1.4.3"."unicode-case" or false); }
+      { "${deps.regex."1.4.3".regex_syntax}"."unicode-gencat" =
+        (f.regex_syntax."${deps.regex."1.4.3".regex_syntax}"."unicode-gencat" or false) ||
+        (regex."1.4.3"."unicode-gencat" or false) ||
+        (f."regex"."1.4.3"."unicode-gencat" or false); }
+      { "${deps.regex."1.4.3".regex_syntax}"."unicode-perl" =
+        (f.regex_syntax."${deps.regex."1.4.3".regex_syntax}"."unicode-perl" or false) ||
+        (regex."1.4.3"."unicode-perl" or false) ||
+        (f."regex"."1.4.3"."unicode-perl" or false); }
+      { "${deps.regex."1.4.3".regex_syntax}"."unicode-script" =
+        (f.regex_syntax."${deps.regex."1.4.3".regex_syntax}"."unicode-script" or false) ||
+        (regex."1.4.3"."unicode-script" or false) ||
+        (f."regex"."1.4.3"."unicode-script" or false); }
+      { "${deps.regex."1.4.3".regex_syntax}"."unicode-segment" =
+        (f.regex_syntax."${deps.regex."1.4.3".regex_syntax}"."unicode-segment" or false) ||
+        (regex."1.4.3"."unicode-segment" or false) ||
+        (f."regex"."1.4.3"."unicode-segment" or false); }
+      { "${deps.regex."1.4.3".regex_syntax}".default = (f.regex_syntax."${deps.regex."1.4.3".regex_syntax}".default or false); }
     ];
-    thread_local."${deps.regex."1.3.9".thread_local}".default = true;
+    thread_local."${deps.regex."1.4.3".thread_local}".default = true;
   }) [
-    (features_.aho_corasick."${deps."regex"."1.3.9"."aho_corasick"}" deps)
-    (features_.memchr."${deps."regex"."1.3.9"."memchr"}" deps)
-    (features_.regex_syntax."${deps."regex"."1.3.9"."regex_syntax"}" deps)
-    (features_.thread_local."${deps."regex"."1.3.9"."thread_local"}" deps)
+    (features_.aho_corasick."${deps."regex"."1.4.3"."aho_corasick"}" deps)
+    (features_.memchr."${deps."regex"."1.4.3"."memchr"}" deps)
+    (features_.regex_syntax."${deps."regex"."1.4.3"."regex_syntax"}" deps)
+    (features_.thread_local."${deps."regex"."1.4.3"."thread_local"}" deps)
   ];
 
 
 # end
-# regex-syntax-0.6.18
+# regex-syntax-0.6.22
 
-  crates.regex_syntax."0.6.18" = deps: { features?(features_.regex_syntax."0.6.18" deps {}) }: buildRustCrate {
+  crates.regex_syntax."0.6.22" = deps: { features?(features_.regex_syntax."0.6.22" deps {}) }: buildRustCrate {
     crateName = "regex-syntax";
-    version = "0.6.18";
+    version = "0.6.22";
     description = "A regular expression parser.";
     authors = [ "The Rust Project Developers" ];
-    sha256 = "0ppcp93sr1j7gi2r4fyksic8fw3nkdmfzd7gqxvhhgx7iivn7qz5";
-    features = mkFeatures (features."regex_syntax"."0.6.18" or {});
+    sha256 = "0r00n2dgyixacl1sczqp18gxf0xh7x272hcdp62412lypba2gqyg";
+    features = mkFeatures (features."regex_syntax"."0.6.22" or {});
   };
-  features_.regex_syntax."0.6.18" = deps: f: updateFeatures f (rec {
+  features_.regex_syntax."0.6.22" = deps: f: updateFeatures f (rec {
     regex_syntax = fold recursiveUpdate {} [
-      { "0.6.18"."unicode" =
-        (f.regex_syntax."0.6.18"."unicode" or false) ||
-        (f.regex_syntax."0.6.18".default or false) ||
-        (regex_syntax."0.6.18"."default" or false); }
-      { "0.6.18"."unicode-age" =
-        (f.regex_syntax."0.6.18"."unicode-age" or false) ||
-        (f.regex_syntax."0.6.18".unicode or false) ||
-        (regex_syntax."0.6.18"."unicode" or false); }
-      { "0.6.18"."unicode-bool" =
-        (f.regex_syntax."0.6.18"."unicode-bool" or false) ||
-        (f.regex_syntax."0.6.18".unicode or false) ||
-        (regex_syntax."0.6.18"."unicode" or false); }
-      { "0.6.18"."unicode-case" =
-        (f.regex_syntax."0.6.18"."unicode-case" or false) ||
-        (f.regex_syntax."0.6.18".unicode or false) ||
-        (regex_syntax."0.6.18"."unicode" or false); }
-      { "0.6.18"."unicode-gencat" =
-        (f.regex_syntax."0.6.18"."unicode-gencat" or false) ||
-        (f.regex_syntax."0.6.18".unicode or false) ||
-        (regex_syntax."0.6.18"."unicode" or false); }
-      { "0.6.18"."unicode-perl" =
-        (f.regex_syntax."0.6.18"."unicode-perl" or false) ||
-        (f.regex_syntax."0.6.18".unicode or false) ||
-        (regex_syntax."0.6.18"."unicode" or false); }
-      { "0.6.18"."unicode-script" =
-        (f.regex_syntax."0.6.18"."unicode-script" or false) ||
-        (f.regex_syntax."0.6.18".unicode or false) ||
-        (regex_syntax."0.6.18"."unicode" or false); }
-      { "0.6.18"."unicode-segment" =
-        (f.regex_syntax."0.6.18"."unicode-segment" or false) ||
-        (f.regex_syntax."0.6.18".unicode or false) ||
-        (regex_syntax."0.6.18"."unicode" or false); }
-      { "0.6.18".default = (f.regex_syntax."0.6.18".default or true); }
+      { "0.6.22"."unicode" =
+        (f.regex_syntax."0.6.22"."unicode" or false) ||
+        (f.regex_syntax."0.6.22".default or false) ||
+        (regex_syntax."0.6.22"."default" or false); }
+      { "0.6.22"."unicode-age" =
+        (f.regex_syntax."0.6.22"."unicode-age" or false) ||
+        (f.regex_syntax."0.6.22".unicode or false) ||
+        (regex_syntax."0.6.22"."unicode" or false); }
+      { "0.6.22"."unicode-bool" =
+        (f.regex_syntax."0.6.22"."unicode-bool" or false) ||
+        (f.regex_syntax."0.6.22".unicode or false) ||
+        (regex_syntax."0.6.22"."unicode" or false); }
+      { "0.6.22"."unicode-case" =
+        (f.regex_syntax."0.6.22"."unicode-case" or false) ||
+        (f.regex_syntax."0.6.22".unicode or false) ||
+        (regex_syntax."0.6.22"."unicode" or false); }
+      { "0.6.22"."unicode-gencat" =
+        (f.regex_syntax."0.6.22"."unicode-gencat" or false) ||
+        (f.regex_syntax."0.6.22".unicode or false) ||
+        (regex_syntax."0.6.22"."unicode" or false); }
+      { "0.6.22"."unicode-perl" =
+        (f.regex_syntax."0.6.22"."unicode-perl" or false) ||
+        (f.regex_syntax."0.6.22".unicode or false) ||
+        (regex_syntax."0.6.22"."unicode" or false); }
+      { "0.6.22"."unicode-script" =
+        (f.regex_syntax."0.6.22"."unicode-script" or false) ||
+        (f.regex_syntax."0.6.22".unicode or false) ||
+        (regex_syntax."0.6.22"."unicode" or false); }
+      { "0.6.22"."unicode-segment" =
+        (f.regex_syntax."0.6.22"."unicode-segment" or false) ||
+        (f.regex_syntax."0.6.22".unicode or false) ||
+        (regex_syntax."0.6.22"."unicode" or false); }
+      { "0.6.22".default = (f.regex_syntax."0.6.22".default or true); }
     ];
   }) [];
 
@@ -3750,47 +3275,6 @@ rec {
       { "0.1.16".default = (f.rustc_demangle."0.1.16".default or true); }
     ];
   }) [];
-
-
-# end
-# rusty-fork-0.2.2
-
-  crates.rusty_fork."0.2.2" = deps: { features?(features_.rusty_fork."0.2.2" deps {}) }: buildRustCrate {
-    crateName = "rusty-fork";
-    version = "0.2.2";
-    description = "Cross-platform library for running Rust tests in sub-processes using a\nfork-like interface.\n";
-    authors = [ "Jason Lingle" ];
-    sha256 = "1qjnfbk0b267mib86p9rvj42xcxv1wady290iblpfnlsyn3achsa";
-    dependencies = mapFeatures features ([
-      (crates."fnv"."${deps."rusty_fork"."0.2.2"."fnv"}" deps)
-      (crates."quick_error"."${deps."rusty_fork"."0.2.2"."quick_error"}" deps)
-      (crates."tempfile"."${deps."rusty_fork"."0.2.2"."tempfile"}" deps)
-    ]
-      ++ (if features.rusty_fork."0.2.2".wait-timeout or false then [ (crates.wait_timeout."${deps."rusty_fork"."0.2.2".wait_timeout}" deps) ] else []));
-    features = mkFeatures (features."rusty_fork"."0.2.2" or {});
-  };
-  features_.rusty_fork."0.2.2" = deps: f: updateFeatures f (rec {
-    fnv."${deps.rusty_fork."0.2.2".fnv}".default = true;
-    quick_error."${deps.rusty_fork."0.2.2".quick_error}".default = true;
-    rusty_fork = fold recursiveUpdate {} [
-      { "0.2.2"."timeout" =
-        (f.rusty_fork."0.2.2"."timeout" or false) ||
-        (f.rusty_fork."0.2.2".default or false) ||
-        (rusty_fork."0.2.2"."default" or false); }
-      { "0.2.2"."wait-timeout" =
-        (f.rusty_fork."0.2.2"."wait-timeout" or false) ||
-        (f.rusty_fork."0.2.2".timeout or false) ||
-        (rusty_fork."0.2.2"."timeout" or false); }
-      { "0.2.2".default = (f.rusty_fork."0.2.2".default or true); }
-    ];
-    tempfile."${deps.rusty_fork."0.2.2".tempfile}".default = true;
-    wait_timeout."${deps.rusty_fork."0.2.2".wait_timeout}".default = true;
-  }) [
-    (features_.fnv."${deps."rusty_fork"."0.2.2"."fnv"}" deps)
-    (features_.quick_error."${deps."rusty_fork"."0.2.2"."quick_error"}" deps)
-    (features_.tempfile."${deps."rusty_fork"."0.2.2"."tempfile"}" deps)
-    (features_.wait_timeout."${deps."rusty_fork"."0.2.2"."wait_timeout"}" deps)
-  ];
 
 
 # end
@@ -3960,30 +3444,30 @@ rec {
 
 
 # end
-# slog-2.5.2
+# slog-2.7.0
 
-  crates.slog."2.5.2" = deps: { features?(features_.slog."2.5.2" deps {}) }: buildRustCrate {
+  crates.slog."2.7.0" = deps: { features?(features_.slog."2.7.0" deps {}) }: buildRustCrate {
     crateName = "slog";
-    version = "2.5.2";
+    version = "2.7.0";
     description = "Structured, extensible, composable logging for Rust";
     authors = [ "Dawid Ciężarkiewicz <dpc@dpc.pw>" ];
-    sha256 = "1mckj3mjmhqhjrs6nkp0zh0jwgppkrq52a5sxh8svd9dqf6j7vl3";
+    sha256 = "0jgfignj5x3ynv6ikmbpncp8xgvq02224fpcg8acjy5n20gk8gii";
     build = "build.rs";
     dependencies = mapFeatures features ([
 ]);
-    features = mkFeatures (features."slog"."2.5.2" or {});
+    features = mkFeatures (features."slog"."2.7.0" or {});
   };
-  features_.slog."2.5.2" = deps: f: updateFeatures f (rec {
+  features_.slog."2.7.0" = deps: f: updateFeatures f (rec {
     slog = fold recursiveUpdate {} [
-      { "2.5.2"."erased-serde" =
-        (f.slog."2.5.2"."erased-serde" or false) ||
-        (f.slog."2.5.2".nested-values or false) ||
-        (slog."2.5.2"."nested-values" or false); }
-      { "2.5.2"."std" =
-        (f.slog."2.5.2"."std" or false) ||
-        (f.slog."2.5.2".default or false) ||
-        (slog."2.5.2"."default" or false); }
-      { "2.5.2".default = (f.slog."2.5.2".default or true); }
+      { "2.7.0"."erased-serde" =
+        (f.slog."2.7.0"."erased-serde" or false) ||
+        (f.slog."2.7.0".nested-values or false) ||
+        (slog."2.7.0"."nested-values" or false); }
+      { "2.7.0"."std" =
+        (f.slog."2.7.0"."std" or false) ||
+        (f.slog."2.7.0".default or false) ||
+        (slog."2.7.0"."default" or false); }
+      { "2.7.0".default = (f.slog."2.7.0".default or true); }
     ];
   }) [];
 
@@ -4945,30 +4429,6 @@ rec {
 
 
 # end
-# vec_map-0.8.2
-
-  crates.vec_map."0.8.2" = deps: { features?(features_.vec_map."0.8.2" deps {}) }: buildRustCrate {
-    crateName = "vec_map";
-    version = "0.8.2";
-    description = "A simple map based on a vector for small integer keys";
-    authors = [ "Alex Crichton <alex@alexcrichton.com>" "Jorge Aparicio <japaricious@gmail.com>" "Alexis Beingessner <a.beingessner@gmail.com>" "Brian Anderson <>" "tbu- <>" "Manish Goregaokar <>" "Aaron Turon <aturon@mozilla.com>" "Adolfo Ochagavía <>" "Niko Matsakis <>" "Steven Fackler <>" "Chase Southwood <csouth3@illinois.edu>" "Eduard Burtescu <>" "Florian Wilkens <>" "Félix Raimundo <>" "Tibor Benke <>" "Markus Siemens <markus@m-siemens.de>" "Josh Branchaud <jbranchaud@gmail.com>" "Huon Wilson <dbau.pp@gmail.com>" "Corey Farwell <coref@rwell.org>" "Aaron Liblong <>" "Nick Cameron <nrc@ncameron.org>" "Patrick Walton <pcwalton@mimiga.net>" "Felix S Klock II <>" "Andrew Paseltiner <apaseltiner@gmail.com>" "Sean McArthur <sean.monstar@gmail.com>" "Vadim Petrochenkov <>" ];
-    sha256 = "1cdbz705d159kpqc1wkyfdjmyxayk6v01f5569ip9gnk7yrgsy6m";
-    dependencies = mapFeatures features ([
-]);
-    features = mkFeatures (features."vec_map"."0.8.2" or {});
-  };
-  features_.vec_map."0.8.2" = deps: f: updateFeatures f (rec {
-    vec_map = fold recursiveUpdate {} [
-      { "0.8.2"."serde" =
-        (f.vec_map."0.8.2"."serde" or false) ||
-        (f.vec_map."0.8.2".eders or false) ||
-        (vec_map."0.8.2"."eders" or false); }
-      { "0.8.2".default = (f.vec_map."0.8.2".default or true); }
-    ];
-  }) [];
-
-
-# end
 # void-1.0.2
 
   crates.void."1.0.2" = deps: { features?(features_.void."1.0.2" deps {}) }: buildRustCrate {
@@ -4988,27 +4448,6 @@ rec {
       { "1.0.2".default = (f.void."1.0.2".default or true); }
     ];
   }) [];
-
-
-# end
-# wait-timeout-0.2.0
-
-  crates.wait_timeout."0.2.0" = deps: { features?(features_.wait_timeout."0.2.0" deps {}) }: buildRustCrate {
-    crateName = "wait-timeout";
-    version = "0.2.0";
-    description = "A crate to wait on a child process with a timeout specified across Unix and\nWindows platforms.\n";
-    authors = [ "Alex Crichton <alex@alexcrichton.com>" ];
-    sha256 = "0l1lsw049536a01gqjb1amr1fddx7656j4qs8m1hjm6nj06qpkry";
-    dependencies = (if (kernel == "linux" || kernel == "darwin") then mapFeatures features ([
-      (crates."libc"."${deps."wait_timeout"."0.2.0"."libc"}" deps)
-    ]) else []);
-  };
-  features_.wait_timeout."0.2.0" = deps: f: updateFeatures f (rec {
-    libc."${deps.wait_timeout."0.2.0".libc}".default = true;
-    wait_timeout."0.2.0".default = (f.wait_timeout."0.2.0".default or true);
-  }) [
-    (features_.libc."${deps."wait_timeout"."0.2.0"."libc"}" deps)
-  ];
 
 
 # end


### PR DESCRIPTION
It’s time for an update run!

I defined a minimum supported rust compiler that we want to
support (1.41.0) and then went through all of our dependencies to
update to the according version and make sure unnecessary features are
disabled.

The list also got sorted by core features vs nice-to-have, so it’s
easier to see which ones are more important to update correctly.

Stripping features from e.g. doctest (which we only use for one tiny
test) made our closure shrink a bit! In general it’s worth
investigating this stuff. I also moved it to dev-dependencies, now
cargo won’t build it if you don’t run the tests.

cc @sternenseemann 

<!--
If this is the first time you are contributing to lorri, please take a look at:
https://github.com/nix-community/lorri/blob/master/CONTRIBUTING.md

Explain the approach you took to resolving the issue and provide necessary context.
There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
-->

### Checklist

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

