### PR TITLE
Fix build loop

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -5,6 +5,25 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 702;
+        changes = ''
+          Fix the build loop.
+
+          Previously, any change (for example a direnv ping or a change in the nix files)
+          would add a new build invocation to the queue, and the builds would all be done
+          one after the other.
+
+          However, a new build will always use the *newest* state of the files anyway,
+          so the CPU time spent on all the other builds will be wasted (and hog your processor).
+
+          Now lorri will only
+          1. finish the current build (if running)
+          2. schedule at maximum one additional build if requested
+
+          This should improve the resource use drastically in some situations.
+        '';
+      }
+      {
         version = 676;
         changes = ''
           Make `lorri daemon` exit with exit code 0 instead of 130/143 on

--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -120,18 +120,6 @@ impl<'a> BuildLoop<'a> {
     #[allow(clippy::drop_copy, clippy::zero_ptr)] // triggered by `select!`
     pub fn forever(&mut self, tx: chan::Sender<LoopHandlerEvent>, rx_ping: chan::Receiver<()>) {
         let mut current_build = BuildState::NotRunning;
-        // The project has just been added, so run the builder in the first iteration
-        // TODO: move this into a ping done outside the forever?
-        self.schedule_build(&mut current_build);
-        tx.send(LoopHandlerEvent::BuildEvent(Event::Started {
-            nix_file: self.project.nix_file.clone(),
-            reason: Reason::ProjectAdded(self.project.nix_file.clone()),
-        }))
-        .expect("could not send event");
-
-        // Drain pings initially: we're going to trigger a first build anyway
-        rx_ping.try_iter().for_each(drop);
-
         let rx_watcher = self.watch.rx.clone();
 
         loop {

--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -184,11 +184,12 @@ impl<'a> BuildLoop<'a> {
     /// This will create GC roots and expand the file watch list for
     /// the evaluation.
     pub fn once(&mut self) -> Result<builder::OutputPaths<roots::RootPath>, BuildError> {
-        let run_result = builder::run(
-            &self.project.nix_file,
-            &self.project.cas,
-            &self.extra_nix_options,
-        )?;
+        let nix_file = self.project.nix_file.clone();
+        let cas = self.project.cas.clone();
+        let extra_nix_options = self.extra_nix_options.clone();
+        let run_result =
+            crate::run_async::Async::run(move || builder::run(&nix_file, &cas, &extra_nix_options))
+                .block()?;
         self.register_paths(&run_result.referenced_paths)?;
         self.root_result(run_result.result)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -170,6 +170,7 @@ impl fmt::Display for BuildError {
     }
 }
 
+// TODO: rethink these constructors
 impl BuildError {
     /// Smart constructor for `BuildError::Io`
     pub fn io<D>(e: D) -> BuildError

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 //! configuration and patterns in to a declarative configuration.
 
 #![warn(missing_docs)]
+// We usually want to use matches for clarity
+#![allow(clippy::match_bool)]
+#![allow(clippy::single_match)]
 
 #[macro_use]
 extern crate structopt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod ops;
 pub mod osstrlines;
 pub mod pathreduction;
 pub mod project;
+pub mod run_async;
 pub mod socket;
 pub mod thread;
 pub mod watch;

--- a/src/ops/upgrade.rs
+++ b/src/ops/upgrade.rs
@@ -126,7 +126,7 @@ pub fn main(upgrade_target: cli::UpgradeTo, cas: &ContentAddressable) -> OpResul
     let changelog: changelog::Log = expr.clone().attribute("changelog").value().unwrap();
 
     println!("Changelog when upgrading from {}:", VERSION_BUILD_REV);
-    for entry in changelog.entries {
+    for entry in changelog.entries.iter().rev() {
         if VERSION_BUILD_REV < entry.version {
             println!();
             println!("{}:", entry.version);

--- a/src/project/roots.rs
+++ b/src/project/roots.rs
@@ -35,14 +35,6 @@ impl OutputPaths<RootPath> {
 
         shell_gc_root.0.exists()
     }
-
-    /// Check that the shell_gc_root is a directory.
-    pub fn shell_gc_root_is_dir(&self) -> bool {
-        match self.shell_gc_root.0.metadata() {
-            Err(_) => false,
-            Ok(m) => m.is_dir(),
-        }
-    }
 }
 
 /// Proxy through the `Display` class for `PathBuf`.

--- a/src/run_async.rs
+++ b/src/run_async.rs
@@ -91,7 +91,7 @@ mod tests {
         // now finish the thread, which will give us the return value on the chan
         tx.send(42).unwrap();
         assert_eq!(
-            c.recv_timeout(std::time::Duration::from_millis(1)),
+            c.recv_timeout(std::time::Duration::from_millis(100)),
             Ok(Ok(42))
         );
         // and we can drop the async, it should not block because the thread has finished and can be joined

--- a/src/run_async.rs
+++ b/src/run_async.rs
@@ -1,0 +1,117 @@
+//! Run a function asynchronously.
+use crate::thread::Pool;
+use crossbeam_channel as chan;
+
+/// Asynchronously execute an action, by executing it in a thread.
+///
+/// ATTN: dropping this will wait for the action to finish, and thus might block for a long time.
+pub struct Async<Res> {
+    // we use a pool with exactly one thread,
+    // because our thread pool will do the resume_unwind dance for us
+    // and thus not lose the stack trace like the naïve implementation would.
+    thread: Pool,
+    result_chan: chan::Receiver<Res>,
+}
+
+impl<Res> Drop for Async<Res> {
+    fn drop(&mut self) {
+        self.thread.join_all_or_panic();
+    }
+}
+
+impl<Res: Send + 'static> Async<Res> {
+    /// Create a new Async that runs a function in a thread.
+    ///
+    /// You can read the result either by blocking
+    /// or by using the `chan` method to get a channel that receives exactly
+    /// one result as soon as the the function is done.
+    pub fn run<F>(f: F) -> Self
+    where
+        F: FnOnce() -> Res,
+        F: std::panic::UnwindSafe,
+        F: Send + 'static,
+    {
+        let (tx, rx) = chan::bounded(1);
+        let mut thread = Pool::new();
+
+        thread.spawn("async thread", move || {
+            let res = f();
+            match tx.try_send(res) {
+                Ok(()) => {},
+                Err(err) => panic!("unable to send the async result, because the channel was disconnected (should never happen): {:?}", err)
+            }
+        }).expect("unable to spawn Async thread, should not happen");
+
+        Async {
+            thread,
+            result_chan: rx,
+        }
+    }
+
+    /// Block until the result is ready.
+    /// Consumes the Async.
+    pub fn block(mut self) -> Res {
+        let res = match self.result_chan.recv() {
+            Ok(res) => res,
+            Err(chan::RecvError) =>
+                panic!("unable to receive the async result, because the channel was disconnected and empty (should never happen)")
+        };
+        // since the function finished, the thread (created in `run()`) will join immediatly after
+        self.thread.join_all_or_panic();
+        res
+    }
+
+    /// Generate a channel receiving the result of the Async once it’s ready.
+    ///
+    /// Make sure you don’t drop the Async before the result is ready,
+    /// since that will block until the function given to `run` is done.
+    ///
+    /// Also if you are waiting on the channel result, don’t block on it as well,
+    /// since that introduces a race condition.
+    pub fn chan(&self) -> chan::Receiver<Res> {
+        self.result_chan.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chan_drop_order() {
+        // we make the async just block on a channel which we can control from outside
+        let (tx, rx) = chan::bounded(1);
+        let a = Async::run(move || rx.recv());
+        let c = a.chan();
+        // nothing has been sent to the thread yet, so timeout
+        assert_eq!(
+            c.recv_timeout(std::time::Duration::from_millis(1)),
+            Err(chan::RecvTimeoutError::Timeout)
+        );
+        // now finish the thread, which will give us the return value on the chan
+        tx.send(42).unwrap();
+        assert_eq!(
+            c.recv_timeout(std::time::Duration::from_millis(1)),
+            Ok(Ok(42))
+        );
+        // and we can drop the async, it should not block because the thread has finished and can be joined
+        drop(a)
+    }
+
+    #[test]
+    fn test_chan_block_still_works() {
+        // check that even after getting a channel the blocking still works
+        let a = Async::run(move || 42);
+        let c = a.chan();
+        assert_eq!(a.block(), 42);
+        // would be disconnected, because the result was already retrieved by the block
+        // and the async went out of scope.
+        // This API is a bit unsafe, but exposing the channel will lead to stuff like this.
+        // We only ever return one result, so if you try to fetch it twice one will fail.
+        assert_eq!(
+            c.recv_timeout(std::time::Duration::from_millis(1)),
+            Err(chan::RecvTimeoutError::Disconnected)
+        );
+        // At least you can’t block twice, because the .block() call consumes the Async
+    }
+}

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -95,7 +95,7 @@ impl Pool {
 
     /// Attempt to join all threads, and if any of them panicked,
     /// also panic this thread.
-    pub fn join_all_or_panic(mut self) {
+    pub fn join_all_or_panic(&mut self) {
         loop {
             if self.threads.is_empty() {
                 return;

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -15,8 +15,6 @@ pub struct Watch {
     /// Event receiver. Process using `Watch::process`.
     pub rx: chan::Receiver<notify::Result<notify::Event>>,
     notify: RecommendedWatcher,
-    /// Set of paths this Watch is watching at the moment.
-    /// Statefully updated by `extend`.
     watches: HashSet<PathBuf>,
 }
 


### PR DESCRIPTION
 fix(build_loop): always schedule at most one other build
80e8eb1

This switches the build loop from blockingly running a build for every
event that ever appeared, to always at most running one additional
build as soon as the current one finishes.

Whenver we start a new build, we take the *current* state of the
environment to run nix, which means that all events that happen
while a build is running (e.g. pings, filesystem events &c.) should be
collapsed into *one* (1) extra build to be scheduled right after the
current build finishes.

So there is now a stateful `current_build` variable, which contains
one `BuildState` that is mutably updated from `NotRunning` to
`Running` and if it’s already running to `RunningAndScheduled`. Then
the “build finished” event becomes just another handler in our giant
`select!`, meaning that as soon as a build finishes we can either go
back to `NotRunning` or go to `Running` if there had been another
build scheduled.

For now this means inlining `once_with_send` into the build loop,
further refactors to follow to make the logic easier to understand.



### Checklist

- [ ] Updated the documentation (code documentation, command help, ...)
- [ ] Tested the change (unit or integration tests)
- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)

<!-- This checklist is here to help you and your reviewers, so feel free to edit it as appropriate,
e.g. bugfixes don't usually require a documentation change. -->

