### PR TITLE
(fix) flush stdout on every event in `lorri internal stream-events`

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -636,7 +636,9 @@ pub fn stream_events(kind: EventKind) -> OpResult {
                                 },
                             )),
                         )
-                            .expect("couldn't serialize event")
+                            .expect("couldn't serialize event");
+                        write!(std::io::stdout(), "\n").expect("couldn't serialize event");
+                        std::io::stdout().flush().expect("couldn't flush serialized event");
                     }
                     _ => (),
                 },


### PR DESCRIPTION
this would cause the output to not appear until next event

lorri still hangs after printing. I am currently investigating if lorri it is a regression.



<!--
Explain the approach you took to resolving the issue and provide necessary context.
There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
-->

- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)
