### PR TITLE
(fix) don't busywait when hitting file descriptor limit

### DIFF
--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -119,7 +119,10 @@ impl Server {
                         .expect("Serve::listen: new thread channel closed");
                 }
                 Err(accept_err) => {
-                    info!("Failed accepting a client connection"; "accept_error" => format!("{:?}", accept_err))
+                    info!("Failed accepting a client connection"; "accept_error" => format!("{:?}", accept_err));
+                    // If we hit an error like `too many open file descriptors`, avoid retrying
+                    // immediately and hogging the CPU in a busy loop.
+                    std::thread::sleep(std::time::Duration::from_millis(100));
                 }
             }
         }


### PR DESCRIPTION
motivation: somehow I had lorri hitting the file descriptor limit and when it does it takes 100% of a cpu.

I might be better to review all possible error and just crash on some of them, instead of retrying in a loop.

- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)
