### PR TITLE
feat(vendor/human-panic): remove red coloring & embarrassing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,6 @@ dependencies = [
  "os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -943,14 +942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,7 +1201,6 @@ dependencies = [
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
-"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thiserror 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 "checksum thiserror-impl 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -20,7 +20,6 @@ rec {
         (cratesIO.crates."os_type"."${deps."human_panic"."1.0.4-alpha.0"."os_type"}" deps)
         (cratesIO.crates."serde"."${deps."human_panic"."1.0.4-alpha.0"."serde"}" deps)
         (cratesIO.crates."serde_derive"."${deps."human_panic"."1.0.4-alpha.0"."serde_derive"}" deps)
-        (cratesIO.crates."termcolor"."${deps."human_panic"."1.0.4-alpha.0"."termcolor"}" deps)
         (cratesIO.crates."toml"."${deps."human_panic"."1.0.4-alpha.0"."toml"}" deps)
         (cratesIO.crates."uuid"."${deps."human_panic"."1.0.4-alpha.0"."uuid"}" deps)
       ]);
@@ -32,7 +31,6 @@ rec {
       os_type."${deps.human_panic."1.0.4-alpha.0".os_type}".default = true;
       serde."${deps.human_panic."1.0.4-alpha.0".serde}".default = true;
       serde_derive."${deps.human_panic."1.0.4-alpha.0".serde_derive}".default = true;
-      termcolor."${deps.human_panic."1.0.4-alpha.0".termcolor}".default = true;
       toml."${deps.human_panic."1.0.4-alpha.0".toml}".default = true;
       uuid = fold recursiveUpdate {} [
         { "${deps.human_panic."1.0.4-alpha.0".uuid}"."v4" = true; }
@@ -43,7 +41,6 @@ rec {
       (cratesIO.features_.os_type."${deps."human_panic"."1.0.4-alpha.0"."os_type"}" deps)
       (cratesIO.features_.serde."${deps."human_panic"."1.0.4-alpha.0"."serde"}" deps)
       (cratesIO.features_.serde_derive."${deps."human_panic"."1.0.4-alpha.0"."serde_derive"}" deps)
-      (cratesIO.features_.termcolor."${deps."human_panic"."1.0.4-alpha.0"."termcolor"}" deps)
       (cratesIO.features_.toml."${deps."human_panic"."1.0.4-alpha.0"."toml"}" deps)
       (cratesIO.features_.uuid."${deps."human_panic"."1.0.4-alpha.0"."uuid"}" deps)
     ];
@@ -281,7 +278,6 @@ rec {
     os_type = "2.2.0";
     serde = "1.0.114";
     serde_derive = "1.0.114";
-    termcolor = "1.1.0";
     toml = "0.5.6";
     uuid = "0.8.1";
   };
@@ -568,9 +564,6 @@ rec {
   deps.term."0.6.1" = {
     dirs = "2.0.2";
     winapi = "0.3.9";
-  };
-  deps.termcolor."1.1.0" = {
-    winapi_util = "0.1.5";
   };
   deps.textwrap."0.11.0" = {
     unicode_width = "0.1.7";

--- a/nix/carnix/crates-io.nix
+++ b/nix/carnix/crates-io.nix
@@ -3871,28 +3871,6 @@ rec {
 
 
 # end
-# termcolor-1.1.0
-
-  crates.termcolor."1.1.0" = deps: { features?(features_.termcolor."1.1.0" deps {}) }: buildRustCrate {
-    crateName = "termcolor";
-    version = "1.1.0";
-    description = "A simple cross platform library for writing colored text to a terminal.\n";
-    authors = [ "Andrew Gallant <jamslam@gmail.com>" ];
-    edition = "2018";
-    sha256 = "10ckhcj1pv4xgxrvby0j1fccanfnyc4fwdlvqr9gm4k35yx0ssci";
-    dependencies = (if kernel == "windows" then mapFeatures features ([
-      (crates."winapi_util"."${deps."termcolor"."1.1.0"."winapi_util"}" deps)
-    ]) else []);
-  };
-  features_.termcolor."1.1.0" = deps: f: updateFeatures f (rec {
-    termcolor."1.1.0".default = (f.termcolor."1.1.0".default or true);
-    winapi_util."${deps.termcolor."1.1.0".winapi_util}".default = true;
-  }) [
-    (features_.winapi_util."${deps."termcolor"."1.1.0"."winapi_util"}" deps)
-  ];
-
-
-# end
 # textwrap-0.11.0
 
   crates.textwrap."0.11.0" = deps: { features?(features_.textwrap."0.11.0" deps {}) }: buildRustCrate {

--- a/vendor/human-panic/Cargo.toml
+++ b/vendor/human-panic/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2018"
 features = ["nightly"]
 
 [dependencies]
-termcolor = "1.0.4"
 uuid = { version = "0.8.0", features = ["v4"], default-features = false }
 serde_derive = "1.0.79"
 toml = "0.5.0"

--- a/vendor/human-panic/src/lib.rs
+++ b/vendor/human-panic/src/lib.rs
@@ -27,8 +27,6 @@
 //! ### Human-Panic Output
 //!
 //! ```txt
-//! Well, this is embarrassing.
-//!
 //! human-panic had a problem and crashed. To help us diagnose the problem you can send us a crash report.
 //!
 //! We have generated a report file at "/var/folders/zw/bpfvmq390lv2c6gn_6byyv0w0000gn/T/report-8351cad6-d2b5-4fe8-accd-1fcbf4538792.toml". Submit an issue or email with the subject of "human-panic Crash Report" and include the report as an attachment.
@@ -51,7 +49,6 @@ use std::borrow::Cow;
 use std::io::{Result as IoResult, Write};
 use std::panic::PanicInfo;
 use std::path::{Path, PathBuf};
-use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 /// A convenient metadata struct that describes a crate
 pub struct Metadata {
@@ -140,11 +137,7 @@ pub fn print_msg<P: AsRef<Path>>(
   let (_version, name, authors, homepage) =
     (&meta.version, &meta.name, &meta.authors, &meta.homepage);
 
-  let stderr = BufferWriter::stderr(ColorChoice::Auto);
-  let mut buffer = stderr.buffer();
-  buffer.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
-
-  writeln!(&mut buffer, "Well, this is embarrassing.\n")?;
+  let mut buffer = std::io::stderr();
   writeln!(
     &mut buffer,
     "{} had a problem and crashed. To help us diagnose the \
@@ -177,9 +170,6 @@ pub fn print_msg<P: AsRef<Path>>(
   )?;
   writeln!(&mut buffer, "Thank you kindly!")?;
 
-  buffer.reset()?;
-
-  stderr.print(&buffer).unwrap();
   Ok(())
 }
 


### PR DESCRIPTION
We don’t need to format errors red, the output will be printed to
stderr and signified by the exit code anyway.

The “well this is embarrassing” part is, yes, embarrassing. Meta.



<!--
Explain the approach you took to resolving the issue and provide necessary context.
There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
-->

- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)
