### PR TITLE
chore(README): adjust CI status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 https://github.com/nix-community/lorri
 
 [![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)
-![CI](https://github.com/nix-community/lorri/workflows/CI/badge.svg?branch=canon)
+[![CI](https://github.com/nix-community/lorri/actions/workflows/ci.yml/badge.svg)](https://github.com/nix-community/lorri/actions/workflows/ci.yml)
 
 lorri is a `nix-shell` replacement for project development. lorri is
 based around fast direnv integration for robust CLI and editor


### PR DESCRIPTION
Apparently the URL for this changed for GitHub actions and the old URL would always show “no status”.



<!--
Explain the approach you took to resolving the issue and provide necessary context.
There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
-->

- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)
