### PR TITLE
filterSource support

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,19 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 872;
+        changes = ''
+          Add support for builtins.filterSource, refine builtins.readDir
+
+          The filter of filterSource is only respected for direct children of
+          the source root.  For example, if you use nix-gitignore, .git is not
+          watched.
+
+          builtins.readDir'ed paths are now not watched recursively, which should
+          greatly reduce inotiy resource consumption.
+        '';
+      }
+      {
         version = 739;
         changes = ''
           Rewrite the internal daemon socket protocol.

--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -10,7 +10,7 @@ use crate::project::roots;
 use crate::project::roots::Roots;
 use crate::project::Project;
 use crate::run_async::Async;
-use crate::watch::Watch;
+use crate::watch::{Watch, WatchPathBuf};
 use crate::NixFile;
 use crossbeam_channel as chan;
 use slog_scope::debug;
@@ -308,7 +308,7 @@ impl<'a> BuildLoop<'a> {
         self.root_result(run_result.result)
     }
 
-    fn register_paths(&mut self, paths: &[PathBuf]) -> Result<(), notify::Error> {
+    fn register_paths(&mut self, paths: &[WatchPathBuf]) -> Result<(), notify::Error> {
         let original_paths_len = paths.len();
         let paths = reduce_paths(&paths);
         debug!("paths reduced"; "from" => original_paths_len, "to" => paths.len());

--- a/src/logged-evaluation.nix
+++ b/src/logged-evaluation.nix
@@ -12,7 +12,7 @@ let
     scopedImport = x: builtins.scopedImport (overrides // x);
     builtins = builtins // {
       readFile = file: builtins.trace "lorri read: '${toString file}'" (builtins.readFile file);
-      readDir = path: builtins.trace "lorri read: '${toString path}'" (builtins.readDir path);
+      readDir = path: builtins.trace "lorri readdir: '${toString path}'" (builtins.readDir path);
     };
   };
 


### PR DESCRIPTION
Motivation: use nix-gitignore and not have to rebuild on each git fetch
I decided accurately respecting the filter in filterSource was too complex, so this implements an approximation.

* adds a way to watch only directory not recursively
* when using filtersource on a path, the path is watch non-recursively, and the children *satisfying the filter* are watched recursively.
This way, .git it ignored.

- [x] Amended the changelog in `release.nix` (see `release.nix` for instructions)
