### PR TITLE
fix(daemon/server): break out of the stream-events handler

### DIFF
--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -89,7 +89,11 @@ impl Server {
                                         for event in rx_event {
                                             match rw.write(communicate::DEFAULT_READ_TIMEOUT, &event) {
                                                 Ok(()) => {},
-                                                Err(err) => debug!("client vanished"; "communication_type" => format!("{:?}", communication_type), "error" => format!("{:?}", err))
+                                                Err(err) => {
+                                                    debug!("client vanished"; "communication_type" => format!("{:?}", communication_type), "error" => format!("{:?}", err));
+                                                    // break out of the loop or the handler is not stopped
+                                                    break;
+                                                }
                                             }
                                         }
                                     },

--- a/src/locate_file.rs
+++ b/src/locate_file.rs
@@ -3,7 +3,7 @@
 use crate::AbsPathBuf;
 use std::env;
 use std::io;
-use std::path::PathBuf;
+use std::path::Path;
 
 /// Error conditions encountered when hunting for a file on disk
 #[derive(Debug)]
@@ -24,7 +24,7 @@ impl From<std::io::Error> for FileLocationError {
 
 /// Search for `name` in the current directory.
 /// If `name` is an absolute path, it returns `name`.
-pub fn in_cwd(name: &PathBuf) -> Result<AbsPathBuf, FileLocationError> {
+pub fn in_cwd(name: &Path) -> Result<AbsPathBuf, FileLocationError> {
     let path = AbsPathBuf::new(env::current_dir()?)
         .unwrap_or_else(|orig| {
             panic!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use lorri::NixFile;
 use slog::{debug, error, o};
 use slog_scope::GlobalLoggerGuard;
 use std::env;
-use std::path::PathBuf;
+use std::path::Path;
 use structopt::StructOpt;
 
 const TRIVIAL_SHELL_SRC: &str = include_str!("./trivial-shell.nix");
@@ -61,9 +61,9 @@ fn install_signal_handler() {
 /// Reads a nix filename given by the user and either returns
 /// the `NixFile` type or exists with a helpful error message
 /// that instructs the user how to write a minimal `shell.nix`.
-fn find_nix_file(shellfile: &PathBuf) -> Result<NixFile, ExitError> {
+fn find_nix_file(shellfile: &Path) -> Result<NixFile, ExitError> {
     // use shell.nix from cwd
-    Ok(NixFile::from(locate_file::in_cwd(&shellfile).map_err(
+    Ok(NixFile::from(locate_file::in_cwd(shellfile).map_err(
         |_| {
             ExitError::user_error(format!(
                 "`{}` does not exist\n\

--- a/src/pathreduction.rs
+++ b/src/pathreduction.rs
@@ -20,7 +20,7 @@ impl PathReduction {
     fn unwrap(self, msg: &'static str) -> PathBuf {
         match self {
             PathReduction::Reduced(p) => p,
-            _ => panic!(msg),
+            _ => panic!("{}", msg),
         }
     }
 }
@@ -105,7 +105,7 @@ pub fn reduce_paths(paths: &[PathBuf]) -> HashSet<PathBuf> {
 ///    (C) it never changes.
 ///
 /// (E) Sub-path to exactly what file was looked at.
-fn reduce_channel_path(path: &PathBuf) -> ReductionOp {
+fn reduce_channel_path(path: &Path) -> ReductionOp {
     let nix_profile = Path::new("/nix/var/nix/profiles/per-user");
 
     // example path: /nix/var/nix/profiles/per-user/root/channels/nixos/....
@@ -147,7 +147,7 @@ fn reduce_channel_path(path: &PathBuf) -> ReductionOp {
 ///
 /// Note that because store paths are immutable, these paths can
 /// be discarded.
-fn reduce_nix_store_path(path: &PathBuf) -> ReductionOp {
+fn reduce_nix_store_path(path: &Path) -> ReductionOp {
     let nix_store = Path::new("/nix/store");
 
     // This is only a valid reduction if the Nix store path

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -126,7 +126,7 @@ impl Watch {
         Ok(())
     }
 
-    fn path_is_interesting(watches: &HashSet<PathBuf>, path: &PathBuf, kind: &EventKind) -> bool {
+    fn path_is_interesting(watches: &HashSet<PathBuf>, path: &Path, kind: &EventKind) -> bool {
         path_match(watches, path)
             && match kind {
                 // We ignore metadata modification events for the profiles directory


### PR DESCRIPTION
If the client disengages, we need to stop the handler immediately,
otherwise we keep it running in the for-loop for all times.

This fixes a problem where any call of the
`lorri internal stream-events --kind snapshot` client
would drop the connection, and the handler would trace it but not stop
itself.

Fixes https://github.com/nix-community/lorri/issues/35



<!--
Explain the approach you took to resolving the issue and provide necessary context.
There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
-->

- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)
