### PR TITLE
Add nix file to watcher immediately

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,18 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 881;
+        changes = ''
+          Fix watcher not starting if the first nix build fails.
+
+          We were not actually watching the nix file, only indirectly picking
+          it up from the first nix build; so if that failed, we’d not watch any file.
+
+          Now lorri will always add the `shell.nix` to the watchlist,
+          ensuring it triggers a rebuild as soon as it is fixed again.
+        '';
+      }
+      {
         version = 872;
         changes = ''
           Add support for builtins.filterSource, refine builtins.readDir

--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -173,7 +173,11 @@ impl<'a> BuildLoop<'a> {
     /// Sends `Event`s over `Self.tx` once they happen.
     /// When new filesystem changes are detected while a build is
     /// still running, it is finished first before starting a new build.
-    pub fn forever(&mut self, tx: chan::Sender<LoopHandlerEvent>, rx_ping: chan::Receiver<()>) {
+    pub fn forever(
+        &mut self,
+        tx: chan::Sender<LoopHandlerEvent>,
+        rx_ping: chan::Receiver<()>,
+    ) -> crate::Never {
         let mut current_build = BuildState::NotRunning;
         let rx_watcher = self.watch.rx.clone();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn find_nix_file(shellfile: &Path) -> Result<NixFile, ExitError> {
     // use shell.nix from cwd
     Ok(NixFile::from(locate_file::in_cwd(shellfile).map_err(
         |_| {
-            ExitError::user_error(format!(
+            ExitError::user_error(anyhow::anyhow!(
                 "`{}` does not exist\n\
                  You can use the following minimal `shell.nix` to get started:\n\n\
                  {}",
@@ -77,8 +77,9 @@ fn find_nix_file(shellfile: &Path) -> Result<NixFile, ExitError> {
 }
 
 fn create_project(paths: &constants::Paths, shell_nix: NixFile) -> Result<Project, ExitError> {
-    Project::new(shell_nix, &paths.gc_root_dir(), paths.cas_store().clone())
-        .map_err(|e| ExitError::temporary(format!("Could not set up project paths: {:#?}", e)))
+    Project::new(shell_nix, &paths.gc_root_dir(), paths.cas_store().clone()).map_err(|err| {
+        ExitError::temporary(anyhow::anyhow!(err).context("Could not set up project paths"))
+    })
 }
 
 /// Run the main function of the relevant command.

--- a/tests/integration/direnvtestcase.rs
+++ b/tests/integration/direnvtestcase.rs
@@ -43,7 +43,9 @@ impl DirenvTestCase {
 
     /// Execute the build loop one time
     pub fn evaluate(&mut self) -> Result<builder::OutputPath<roots::RootPath>, BuildError> {
-        BuildLoop::new(&self.project, NixOptions::empty()).once()
+        BuildLoop::new(&self.project, NixOptions::empty())
+            .expect("could not set up build loop")
+            .once()
     }
 
     /// Run `direnv allow` and then `direnv export json`, and return


### PR DESCRIPTION
I noticed that lorri would not pick up any filesystem changes if the
first nix build fails after starting to watch a project; we didn’t
actually add the nix file itself to the watcher before the first
build, it was picked up implicitly by the first evaluation output.

Thus if nix failed on the first run, the build loop would never be
triggered again by any filesystem events, and pings from `lorri
direnv` don’t work for this anymore, since they only trigger a rebuild
if the project is not yet watched.

cc @symphorien @sternenseemann 

<!--
Explain the approach you took to resolving the issue and provide necessary context.
There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
-->

- [x] Amended the changelog in `release.nix` (see `release.nix` for instructions)
