### PR TITLE
Ops direnv improve warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,8 @@ fn run_command(log: slog::Logger, opts: Arguments) -> OpResult {
     let without_project = || slog_scope::set_global_logger(log.clone());
     let with_project = |nix_file| -> std::result::Result<(Project, GlobalLoggerGuard), ExitError> {
         let project = create_project(&lorri::ops::get_paths()?, find_nix_file(nix_file)?)?;
-        let guard = slog_scope::set_global_logger(log.new(o!("expr" => project.nix_file.clone())));
+        let guard =
+            slog_scope::set_global_logger(log.new(o!("nix_file" => project.nix_file.clone())));
         Ok((project, guard))
     };
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -133,10 +133,6 @@ pub fn direnv<W: std::io::Write>(project: Project, mut shell_output: W) -> OpRes
             warn!("lorri daemon is not running and this project has not yet been evaluated, please run `lorri daemon`"),
     }
 
-    if std::env::var("DIRENV_IN_ENVRC") != Ok(String::from("1")) {
-        warn!("`lorri direnv` should be executed by direnv from within an `.envrc` file")
-    }
-
     // direnv interprets stdout as a script that it evaluates. That is why (1) the logger for
     // `lorri direnv` outputs to stderr by default (to avoid corrupting the script) and (2) we
     // can't use the stderr logger here.
@@ -161,6 +157,12 @@ watch_file "$EVALUATION_ROOT"
         include_str!("./ops/direnv/envrc.bash")
     )
     .expect("failed to write shell output");
+
+    // direnv provides us with an environment variable if we are inside of its envrc execution.
+    // Thus we can show a warning if the user runs it on their command line.
+    if std::env::var("DIRENV_IN_ENVRC") != Ok(String::from("1")) {
+        warn!("`lorri direnv` should be executed by direnv from within an `.envrc` file. Run `lorri init` to get started.")
+    }
 
     ok()
 }


### PR DESCRIPTION
 fix(ops/direnv): print the .envrc warning *after* the script
0d5e7c5

The warning would be completely invisible, since the script is higher
than a typical screenheight, so let’s print it at the end.

Also add a hint on how to generate `.envrc`, because a new user likely
would try this command and might not know about `lorri init`.

