### PR TITLE
prepend XDG_{CONFIG,DATA}_DIRS

### DIFF
--- a/src/ops/direnv/envrc.bash
+++ b/src/ops/direnv/envrc.bash
@@ -156,6 +156,11 @@ function declare() {
         "preHook="*) punt;;
         "origPreHook="*) move "origPreHook" "preHook" "$@";;
 
+        # https://github.com/nix-community/lorri/issues/48 and
+        # https://github.com/nix-community/home-manager/blob/master/modules/misc/xdg-system-dirs.nix#L16-L36
+        "XDG_DATA_DIRS="*) prepend "XDG_DATA_DIRS" ":" "$@";;
+        "XDG_CONFIG_DIRS="*) prepend "XDG_CONFIG_DIRS" ":" "$@";;
+
         *) varmap "$@" ;;
     esac
 }

--- a/src/ops/direnv/envrc.bash
+++ b/src/ops/direnv/envrc.bash
@@ -158,6 +158,7 @@ function declare() {
 
         # https://github.com/nix-community/lorri/issues/48 and
         # https://github.com/nix-community/home-manager/blob/master/modules/misc/xdg-system-dirs.nix#L16-L36
+        # required for bash completions https://github.com/NixOS/nixpkgs/pull/103501
         "XDG_DATA_DIRS="*) prepend "XDG_DATA_DIRS" ":" "$@";;
         "XDG_CONFIG_DIRS="*) prepend "XDG_CONFIG_DIRS" ":" "$@";;
 


### PR DESCRIPTION
Closes #2, Closes #48
<!--
Explain the approach you took to resolving the issue and provide necessary context.
There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
-->

Bash completions for home-manager broke in directories where lorri is used because XDG_DATA_DIRS got overwritten. I decided we should prepend it instead. I also searched home-manager for similar envs and found another one which I think we should prepend by default.

- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)
