### PR TITLE
fix(daemon): fix fd leak when writing yields BrokenPipe

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,12 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 889;
+        changes = ''
+          Fix another file descriptor leak in the daemon.
+        '';
+      }
+      {
         version = 886;
         changes = ''
           Various fixes to lorri internal stream-events after daemon socket

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -113,7 +113,8 @@ impl Server {
                                     match rw.write(communicate::DEFAULT_READ_TIMEOUT, &event) {
                                         Ok(()) => {}
                                         Err(err) => {
-                                            debug!("client vanished"; "communication_type" => format!("{:?}", communication_type), "error" => format!("{:?}", err))
+                                            debug!("client vanished, closing socket"; "communication_type" => format!("{:?}", communication_type), "error" => format!("{:?}", err));
+                                            break;
                                         }
                                     }
                                 }


### PR DESCRIPTION
we would be waiting on read on an empty pipe for ever.

the leak is hit by running lorri internal stream-events --kind snapshot in a loop

- [x] Amended the changelog in `release.nix` (see `release.nix` for instructions)
