### PR TITLE
feature: add a command to remove gc roots for old or removed projects

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,10 +6,17 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
-        version = 889;
+        version = 900;
         changes = ''
-          Fix another file descriptor leak in the daemon.
+          Add a `lorri gc` command to allow the gc to operate on old or removed
+          projects.
         '';
+      }
+      {
+       version = 889;
+       changes = ''
+         Fix another file descriptor leak in the daemon.
+       '';
       }
       {
         version = 886;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@
 //
 // See MAINTAINERS.md for details on internal and non-internal commands.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "lorri")]
@@ -41,6 +41,10 @@ pub enum Command {
     /// direnv)"`
     #[structopt(name = "direnv")]
     Direnv(DirenvOptions),
+
+    /// Remove lorri garbage collection roots that point to removed shell.nix files
+    #[structopt(name = "gc")]
+    Gc(GcOptions),
 
     /// Show information about a lorri project
     #[structopt(name = "info")]
@@ -92,6 +96,93 @@ pub struct InfoOptions {
     // file was causing problems when they submit a bug report.
     #[structopt(long = "shell-file", parse(from_os_str))]
     pub nix_file: PathBuf,
+}
+
+/// Parses a duration from a timestamp like 30d, 2m.
+fn human_friendly_duration(s: &str) -> Result<Duration, String> {
+    let multiplier = if s.ends_with("d") {
+        24 * 60 * 60
+    } else if s.ends_with("m") {
+        30 * 24 * 60 * 60
+    } else if s.ends_with("y") {
+        365 * 24 * 60 * 60
+    } else {
+        return Err(format!(
+            "Invalid duration: «{}» should end with d, m or y.",
+            s
+        ));
+    };
+    let integer_part = match s.get(0..(s.len() - 1)) {
+        Some(x) => x,
+        None => return Err(format!("Invalid duration: «{}» has no integer part.", s)),
+    };
+    let n: Result<u64, std::num::ParseIntError> = integer_part.parse();
+    match n {
+        Ok(n) => Ok(Duration::from_secs(n * multiplier)),
+        Err(e) => Err(format!(
+            "Invalid duration: «{}» is not an integer: {}",
+            integer_part, e
+        )),
+    }
+}
+
+#[test]
+fn test_human_friendly_duration() {
+    assert_eq!(
+        human_friendly_duration("1d"),
+        Ok(Duration::from_secs(24 * 60 * 60))
+    );
+    assert_eq!(
+        human_friendly_duration("2d"),
+        Ok(Duration::from_secs(2 * 24 * 60 * 60))
+    );
+    assert_eq!(
+        human_friendly_duration("2m"),
+        Ok(Duration::from_secs(2 * 30 * 24 * 60 * 60))
+    );
+    assert_eq!(
+        human_friendly_duration("2y"),
+        Ok(Duration::from_secs(2 * 365 * 24 * 60 * 60))
+    );
+    assert!(human_friendly_duration("1").is_err());
+    assert!(human_friendly_duration("1dd").is_err());
+    assert!(human_friendly_duration("dd").is_err());
+    assert!(human_friendly_duration("d").is_err());
+    assert!(human_friendly_duration("1j").is_err());
+    assert!(human_friendly_duration("é").is_err());
+}
+
+/// Options for the `gc` subcommand.
+#[derive(StructOpt, Debug)]
+pub struct GcOptions {
+    /// Machine readable output
+    #[structopt(long)]
+    pub json: bool,
+
+    #[structopt(subcommand)]
+    /// Subcommand for lorri gc
+    pub action: GcSubcommand,
+}
+
+#[derive(Debug, StructOpt)]
+/// Subcommand for lorri gc
+pub enum GcSubcommand {
+    /// Prints the gc roots that lorri created.
+    #[structopt(name = "info")]
+    Info,
+    /// Removes the gc roots associated to projects whose nix file vanished.
+    #[structopt(name = "rm")]
+    Rm {
+        /// Also delete the root associated with these shell files
+        #[structopt(long = "shell-file")]
+        shell_file: Vec<PathBuf>,
+        /// Delete the root of all projects
+        #[structopt(long)]
+        all: bool,
+        /// Also delete the root of projects that were last built before this amount of time, e.g. 30d.
+        #[structopt(long = "older-than", parse(try_from_str = "human_friendly_duration"))]
+        older_than: Option<Duration>,
+    },
 }
 
 /// Options for the `shell` subcommand.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -52,13 +52,18 @@ impl Paths {
             std::fs::create_dir_all(&dir).and(Ok(dir))
         };
 
-        let abs_cache_dir =
-            crate::AbsPathBuf::new(pd.cache_dir().to_owned()).unwrap_or_else(|cd| {
-                panic!(
-                    "Your cache directory is not an absolute path! It is: {}",
-                    cd.display()
-                )
-            });
+        let cache_dir = pd.cache_dir();
+        // canonicalize is used to make tests easier
+        let canon_cache_dir = match cache_dir.canonicalize() {
+            Ok(c) => c,
+            Err(_) => cache_dir.to_owned(),
+        };
+        let abs_cache_dir = crate::AbsPathBuf::new(canon_cache_dir).unwrap_or_else(|cd| {
+            panic!(
+                "Your cache directory is not an absolute path! It is: {}",
+                cd.display()
+            )
+        });
 
         let gc_root_dir = abs_cache_dir.join("gc_roots");
         let cas_dir = abs_cache_dir.join("cas");

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,7 @@ fn run_command(logger: &slog::Logger, opts: Arguments) -> Result<(), ExitError> 
             let (project, _logger) = with_project(&opts.nix_file)?;
             ops::info(project)
         }
+        Command::Gc(opts) => ops::gc(logger, opts),
         Command::Direnv(opts) => {
             let (project, logger) = with_project(&opts.nix_file)?;
             ops::direnv(project, /* shell_output */ std::io::stdout(), &logger)

--- a/tests/integration/gc.rs
+++ b/tests/integration/gc.rs
@@ -1,3 +1,5 @@
+use directories::ProjectDirs;
+
 fn cargo_bin(name: &str) -> std::path::PathBuf {
     std::env::current_exe()
         .ok()
@@ -58,7 +60,9 @@ derivation {
         .contains(&"done"));
 
     //look for the gc root
-    let gc_roots = home.join(".cache").join("lorri").join("gc_roots");
+    let pd = ProjectDirs::from("com.github.nix-community.lorri", "lorri", "lorri")
+        .expect("determining project directory");
+    let gc_roots = pd.cache_dir().join("gc_roots");
     let mut subdirs = std::fs::read_dir(&gc_roots)
         .expect("readdir")
         .into_iter()

--- a/tests/integration/gc.rs
+++ b/tests/integration/gc.rs
@@ -1,0 +1,114 @@
+fn cargo_bin(name: &str) -> std::path::PathBuf {
+    std::env::current_exe()
+        .ok()
+        .map(|mut path| {
+            path.pop();
+            if path.ends_with("deps") {
+                path.pop();
+            }
+            path.join(name)
+        })
+        .unwrap()
+}
+
+fn run_lorri<T: AsRef<std::ffi::OsStr>>(args: Vec<T>) -> std::io::Result<String> {
+    let out = std::process::Command::new(cargo_bin("lorri"))
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .output()?;
+    let mut res = String::from_utf8(out.stdout).expect("non utf8 output");
+    res.push_str(std::str::from_utf8(&out.stderr).expect("non utf8 stderr"));
+    Ok(res)
+}
+
+#[test]
+fn gc() -> std::io::Result<()> {
+    let testdir = tempfile::tempdir().expect("tempdirfailed");
+    let project = testdir.path().join("project");
+    std::fs::create_dir(&project).expect("mkdir project");
+    let nix_file = project.join("shell.nix");
+    std::fs::write(
+        &nix_file,
+        r#"
+derivation {
+  name = "bogus";
+  builder = ./builder.sh;
+  system = builtins.currentSystem;
+  MARKER = "foo";
+}
+    "#,
+    )
+    .expect("writing shell.nix");
+    std::fs::write(
+        &project.join("builder.sh"),
+        r#"
+#!/bin/sh
+    "#,
+    )
+    .expect("writing builder.sh");
+
+    let home = testdir.path().join("home");
+    std::env::set_var("HOME", &home);
+    std::env::remove_var("XDG_CONFIG_HOME");
+    std::env::remove_var("XDG_CACHE_HOME");
+    std::env::set_current_dir(&project).expect("cd");
+    // build the project
+    assert!(dbg!(run_lorri(vec!["shell", "--shell-file", "shell.nix"]))
+        .expect("running lorri shell")
+        .contains(&"done"));
+
+    //look for the gc root
+    let gc_roots = home.join(".cache").join("lorri").join("gc_roots");
+    let mut subdirs = std::fs::read_dir(&gc_roots)
+        .expect("readdir")
+        .into_iter()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        subdirs.len(),
+        1,
+        "{}!=1 gc roots were created",
+        subdirs.len()
+    );
+    let subdir = subdirs.drain(..).next().unwrap().expect("direntry").path();
+    let gc_root_dir = subdir.join("gc_root");
+    let root = gc_root_dir.join("shell_gc_root");
+    assert!(std::fs::read_link(&root)
+        .expect("readlink gc root")
+        .starts_with("/nix/store"));
+
+    let nix_file_symlink = gc_root_dir.join("nix_file");
+    assert_eq!(
+        std::fs::read_link(&nix_file_symlink).expect("readlink nix_file"),
+        nix_file
+    );
+
+    // now run the gc, it should find the gc root
+    let out = run_lorri(vec!["gc", "--json", "rm"]).unwrap();
+    assert_eq!(out, "[]");
+    // it should also not have removed it
+    let out = run_lorri(vec!["gc", "info"]).unwrap();
+    assert!(dbg!(out).contains(&dbg!(subdir.display().to_string())));
+    // Now remove the project
+    let backup_file = project.join("shell.nix.bak");
+    std::fs::rename(&nix_file, &backup_file).expect("rename");
+    assert!(std::fs::metadata(&nix_file_symlink).is_err());
+    // it should be labeled as dead, but not removed by --print-roots
+    let out = run_lorri(vec!["gc", "info"]).unwrap();
+    assert!(dbg!(&out).contains(&dbg!(subdir.display().to_string())));
+    assert!(dbg!(out).contains("[dead]"));
+    // now remove it
+    let out = run_lorri(vec!["gc", "--json", "rm"]).unwrap();
+    assert!(dbg!(&out).contains(&dbg!(subdir.display().to_string())));
+    let out = run_lorri(vec!["gc", "--json", "rm"]).unwrap();
+    assert_eq!(out, "[]");
+    // rebuild the project
+    std::fs::rename(&backup_file, &nix_file).expect("rename back");
+    assert!(dbg!(run_lorri(vec!["shell", "--shell-file", "shell.nix"]))
+        .expect("running lorri shell")
+        .contains(&"done"));
+    // everything back to normal
+    let out = run_lorri(vec!["gc", "info"]).unwrap();
+    assert!(dbg!(&out).contains(&dbg!(subdir.display().to_string())));
+    assert!(dbg!(out).contains(&dbg!(nix_file.display().to_string())));
+    Ok(())
+}

--- a/tests/integration/gc.rs
+++ b/tests/integration/gc.rs
@@ -28,6 +28,7 @@ fn gc() -> std::io::Result<()> {
     let testdir = tempfile::tempdir().expect("tempdirfailed");
     let project = testdir.path().join("project");
     std::fs::create_dir(&project).expect("mkdir project");
+    let project = project.canonicalize().expect("canonicalize project");
     let nix_file = project.join("shell.nix");
     std::fs::write(
         &nix_file,
@@ -50,6 +51,8 @@ derivation {
     .expect("writing builder.sh");
 
     let home = testdir.path().join("home");
+    std::fs::create_dir(&home).expect("mkdir home");
+    let home = home.canonicalize().expect("canonicalize home");
     std::env::set_var("HOME", &home);
     std::env::remove_var("XDG_CONFIG_HOME");
     std::env::remove_var("XDG_CACHE_HOME");
@@ -62,7 +65,11 @@ derivation {
     //look for the gc root
     let pd = ProjectDirs::from("com.github.nix-community.lorri", "lorri", "lorri")
         .expect("determining project directory");
-    let gc_roots = pd.cache_dir().join("gc_roots");
+    let gc_roots = pd
+        .cache_dir()
+        .canonicalize()
+        .expect("canonicalize gc_root dir")
+        .join("gc_roots");
     let mut subdirs = std::fs::read_dir(&gc_roots)
         .expect("readdir")
         .into_iter()

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -9,4 +9,5 @@ mod direnv;
 mod direnvtestcase;
 mod envrc;
 mod envrctestcase;
+mod gc;
 mod trivial;


### PR DESCRIPTION
I copied the functionality and option names of `nix-store --gc --print-roots` and `nix-collect-garbage --delete-older-than`. To print the original project a gc root corresponds to, I store a symlink to the shell.nix file along with the gc root.

- [x] Amended the changelog in `release.nix` (see `release.nix` for instructions)
