### PR TITLE
ci: use cachix auth token

### DIFF
--- a/.github/workflows/ci.nix
+++ b/.github/workflows/ci.nix
@@ -18,7 +18,7 @@ let
     uses = "cachix/cachix-action@v10";
     "with" = {
       name = "nix-community";
-      signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}";
+      authToken = "\${{ secrets.CACHIX_AUTH_TOKEN }}";
     };
   };
   # required to set up rust-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Cachix
         uses: cachix/cachix-action@v10
         with:
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: nix-community
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build
         run: nix-build
       - name: Install
@@ -35,8 +35,8 @@ jobs:
       - name: Cachix
         uses: cachix/cachix-action@v10
         with:
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: nix-community
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build
         run: nix-build
       - name: Install
@@ -56,8 +56,8 @@ jobs:
       - name: Cachix
         uses: cachix/cachix-action@v10
         with:
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: nix-community
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build w/ overlay (stable)
         run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json
   overlay-ubuntu-latest:
@@ -73,8 +73,8 @@ jobs:
       - name: Cachix
         uses: cachix/cachix-action@v10
         with:
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: nix-community
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build w/ overlay (stable)
         run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json
   rust-each-unit-macos-latest:
@@ -90,8 +90,8 @@ jobs:
       - name: Cachix
         uses: cachix/cachix-action@v10
         with:
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: nix-community
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Add rustc to PATH
         run: |
           set -euo pipefail
@@ -122,8 +122,8 @@ jobs:
       - name: Cachix
         uses: cachix/cachix-action@v10
         with:
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: nix-community
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Add rustc to PATH
         run: |
           set -euo pipefail
@@ -154,8 +154,8 @@ jobs:
       - name: Cachix
         uses: cachix/cachix-action@v10
         with:
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: nix-community
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Add rustc to PATH
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: cachix/cachix-action@v10
         with:
           name: nix-community
-          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build
         run: nix-build
       - name: Install
@@ -36,7 +36,7 @@ jobs:
         uses: cachix/cachix-action@v10
         with:
           name: nix-community
-          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build
         run: nix-build
       - name: Install
@@ -57,7 +57,7 @@ jobs:
         uses: cachix/cachix-action@v10
         with:
           name: nix-community
-          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build w/ overlay (stable)
         run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json
   overlay-ubuntu-latest:
@@ -74,7 +74,7 @@ jobs:
         uses: cachix/cachix-action@v10
         with:
           name: nix-community
-          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build w/ overlay (stable)
         run: nix-build ./nix/overlay.nix -A lorri --arg pkgs ./nix/nixpkgs-stable.json
   rust-each-unit-macos-latest:
@@ -91,7 +91,7 @@ jobs:
         uses: cachix/cachix-action@v10
         with:
           name: nix-community
-          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Add rustc to PATH
         run: |
           set -euo pipefail
@@ -123,7 +123,7 @@ jobs:
         uses: cachix/cachix-action@v10
         with:
           name: nix-community
-          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Add rustc to PATH
         run: |
           set -euo pipefail
@@ -155,7 +155,7 @@ jobs:
         uses: cachix/cachix-action@v10
         with:
           name: nix-community
-          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Add rustc to PATH
         run: |
           set -euo pipefail


### PR DESCRIPTION
Tokens are easier to rotate than signing keys



<!--
Explain the approach you took to resolving the issue and provide necessary context.
There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
-->

- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)
