### PR TITLE
Solution for systemd without nix-darwin

### DIFF
--- a/contrib/daemon.md
+++ b/contrib/daemon.md
@@ -47,9 +47,25 @@ setup](#verify-the-setup) to check that everything works as expected.
 
 This approach uses macOS's [launchd](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html), which is used to manage launch daemons.
 
-1. download this [gist](https://gist.github.com/abhillman/c7e8bf088edcfcc3e7a510501ceeb835)
-1. move the gist to `~/Library/LaunchAgents/nix.lorri.plist`
-1. run `launchctl load -w ~/Library/LaunchAgents/nix.lorri.plist`
+1. write the following `plist` file to 
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>nix.lorri</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>lorri</string>
+		<string>daemon</string>
+	</array>
+</dict>
+</plist>
+```
+
+2. run `launchctl load -w ~/Library/LaunchAgents/nix.lorri.plist`
 
 Alternatively, one can reference the above `launchd` documentation or use a tool like [https://launched.zerowidth.com](https://launched.zerowidth.com) to easily create a `launchd` `plist` file.
 

--- a/contrib/daemon.md
+++ b/contrib/daemon.md
@@ -51,7 +51,7 @@ This approach uses macOS's [launchd](https://developer.apple.com/library/archive
 1. move the gist to `~/Library/LaunchAgents/nix.lorri.plist`
 1. run `launchctl load -w ~/Library/LaunchAgents/nix.lorri.plist`
 
-Alternatively, one can reference the above `launchd` documentation or use a tool like [https://launched.zerowidth.com] to easily create a `launchd` `plist` file.
+Alternatively, one can reference the above `launchd` documentation or use a tool like [https://launched.zerowidth.com](https://launched.zerowidth.com) to easily create a `launchd` `plist` file.
 
 ## Run `lorri daemon` on macOS with Nix (using [nix-darwin](https://github.com/LnL7/nix-darwin))
 

--- a/contrib/daemon.md
+++ b/contrib/daemon.md
@@ -43,6 +43,10 @@ $ mkdir -p ~/.config/systemd/user && \
 The lorri daemon will now be started on demand by systemd. See [Verify the
 setup](#verify-the-setup) to check that everything works as expected.
 
+## Run `lorri daemon` on macOS with Nix
+
+Use [https://launched.zerowidth.com] to easily create a [`systemd` plist file](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html).
+
 ## Run `lorri daemon` on macOS with Nix (using [nix-darwin](https://github.com/LnL7/nix-darwin))
 
 The following user contributions should help you get started:

--- a/contrib/daemon.md
+++ b/contrib/daemon.md
@@ -45,7 +45,13 @@ setup](#verify-the-setup) to check that everything works as expected.
 
 ## Run `lorri daemon` on macOS with Nix
 
-Use [https://launched.zerowidth.com] to easily create a [`systemd` plist file](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html).
+This approach uses macOS's [launchd](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html), which is used to manage launch daemons.
+
+1. download this [gist](https://gist.github.com/abhillman/c7e8bf088edcfcc3e7a510501ceeb835)
+1. move the gist to `~/Library/LaunchAgents/nix.lorri.plist`
+1. run `launchctl load -w ~/Library/LaunchAgents/nix.lorri.plist`
+
+Alternatively, one can reference the above `launchd` documentation or use a tool like [https://launched.zerowidth.com] to easily create a `launchd` `plist` file.
 
 ## Run `lorri daemon` on macOS with Nix (using [nix-darwin](https://github.com/LnL7/nix-darwin))
 

--- a/contrib/daemon.md
+++ b/contrib/daemon.md
@@ -47,7 +47,7 @@ setup](#verify-the-setup) to check that everything works as expected.
 
 This approach uses macOS's [launchd](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html), which is used to manage launch daemons.
 
-1. write the following `plist` file to 
+1. write the following `plist` file to `~/Library/LaunchAgents/nix.lorri.plist`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Document how to setup systemd without `nix-darwin` for `macOS`

- [ ] ~Amended the changelog in `release.nix` (see `release.nix` for instructions)~ not sure that this is applicable here
