### PR TITLE
Cleaning up clippy warnings from older style of Rust

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -48,7 +48,9 @@ let
 
   buildInputs = [
     pkgs.cargo
-    pkgs.rustup
+    pkgs.rustc
+    pkgs.rustfmt
+    pkgs.rustPackages.clippy
     pkgs.git
     pkgs.direnv
     pkgs.crate2nix
@@ -71,7 +73,9 @@ pkgs.mkShell (
   {
     name = "lorri";
     buildInputs = buildInputs
-    ++ pkgs.lib.optionals isDevelopmentShell [ ];
+    ++ pkgs.lib.optionals isDevelopmentShell [
+      pkgs.rust-analyzer
+    ];
 
     inherit BUILD_REV_COUNT RUN_TIME_CLOSURE;
 

--- a/src/build_loop.rs
+++ b/src/build_loop.rs
@@ -338,7 +338,7 @@ impl<'a> BuildLoop<'a> {
 
     fn register_paths(&mut self, paths: &[WatchPathBuf]) -> Result<(), notify::Error> {
         let original_paths_len = paths.len();
-        let paths = reduce_paths(&paths);
+        let paths = reduce_paths(paths);
         debug!(self.logger, "paths reduced"; "from" => original_paths_len, "to" => paths.len());
 
         // add all new (reduced) nix sources to the input source watchlist

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -234,14 +234,14 @@ fn instrumented_instantiation(
     // TODO: see ::nix::CallOpts::paths for the problem with this
     let gc_root_dir = tempfile::TempDir::new()?;
 
-    cmd.args(&[
+    cmd.args([
         // verbose mode prints the files we track
         OsStr::new("-vv"),
     ]);
     // put the passed extra options at the front
     // to make them more visible in traces
     cmd.args(extra_nix_options.to_nix_arglist());
-    cmd.args(&[
+    cmd.args([
         // we add a temporary indirect GC root
         OsStr::new("--add-root"),
         gc_root_dir.path().join("result").as_os_str(),
@@ -253,8 +253,8 @@ fn instrumented_instantiation(
         // the source file
         OsStr::new("--argstr"),
     ]);
-    cmd.args(&[OsStr::new("src"), nix_file.as_absolute_path().as_os_str()]);
-    cmd.args(&[
+    cmd.args([OsStr::new("src"), nix_file.as_absolute_path().as_os_str()]);
+    cmd.args([
         // instrumented by `./logged-evaluation.nix`
         OsStr::new("--"),
         &logged_evaluation_nix.as_path().as_os_str(),
@@ -395,7 +395,7 @@ pub fn run(
     extra_nix_options: &NixOptions,
     logger: &slog::Logger,
 ) -> Result<RunResult, BuildError> {
-    let inst_info = instrumented_instantiation(root_nix_file, cas, &extra_nix_options, logger)?;
+    let inst_info = instrumented_instantiation(root_nix_file, cas, extra_nix_options, logger)?;
     let buildoutput = build(inst_info.output.path, logger)?;
     Ok(RunResult {
         referenced_paths: inst_info.referenced_paths,
@@ -457,13 +457,13 @@ where
         Some(linestr) => {
             // Lines about evaluating a file are much more common, so looking
             // for them first will reduce comparisons.
-            if let Some(matches) = EVAL_FILE.captures(&linestr) {
+            if let Some(matches) = EVAL_FILE.captures(linestr) {
                 LogDatum::NixSourceFile(PathBuf::from(&matches["source"]))
-            } else if let Some(matches) = COPIED_SOURCE.captures(&linestr) {
+            } else if let Some(matches) = COPIED_SOURCE.captures(linestr) {
                 LogDatum::CopiedSource(PathBuf::from(&matches["source"]))
-            } else if let Some(matches) = LORRI_READ.captures(&linestr) {
+            } else if let Some(matches) = LORRI_READ.captures(linestr) {
                 LogDatum::ReadRecursively(PathBuf::from(&matches["source"]))
-            } else if let Some(matches) = LORRI_READ.captures(&linestr) {
+            } else if let Some(matches) = LORRI_READ.captures(linestr) {
                 LogDatum::ReadDir(PathBuf::from(&matches["source"]))
             } else {
                 LogDatum::Text(linestr.to_owned())
@@ -559,7 +559,7 @@ derivation {{
 
         let inner_drv = drv(
             "dep",
-            r##"
+            r#"
 args = [
     "-c"
     ''
@@ -567,7 +567,7 @@ args = [
     printf '"\xab\xbc\xcd\xde\xde\xef"'
     echo > $out
     ''
-];"##,
+];"#,
         );
 
         let nix_drv = format!(
@@ -600,7 +600,7 @@ in {}
 
         let d = crate::NixFile::from(cas.file_from_string(&drv(
             "shell",
-            &format!("dep = {};", drv("dep", r##"args = [ "-c" "exit 1" ];"##)),
+            &format!("dep = {};", drv("dep", r#"args = [ "-c" "exit 1" ];"#)),
         ))?);
 
         if let Err(BuildError::Exit { .. }) = run(
@@ -655,13 +655,13 @@ dir-as-source = ./dir;
         let foo = root.join("foo");
         std::fs::create_dir(&foo)?;
         let dir = root.join("dir");
-        std::fs::create_dir(&dir)?;
+        std::fs::create_dir(dir)?;
         let foo_default = &foo.join("default.nix");
-        std::fs::write(&foo_default, "import ./baz")?;
+        std::fs::write(foo_default, "import ./baz")?;
         let foo_bar = &foo.join("bar");
-        std::fs::write(&foo_bar, "This file should not be watched")?;
+        std::fs::write(foo_bar, "This file should not be watched")?;
         let foo_baz = &foo.join("baz");
-        std::fs::write(&foo_baz, "\"This file should be watched\"")?;
+        std::fs::write(foo_baz, "\"This file should be watched\"")?;
 
         let cas =
             ContentAddressable::new(crate::AbsPathBuf::new(cas_tmp.path().join("cas")).unwrap())?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,11 +100,11 @@ pub struct InfoOptions {
 
 /// Parses a duration from a timestamp like 30d, 2m.
 fn human_friendly_duration(s: &str) -> Result<Duration, String> {
-    let multiplier = if s.ends_with("d") {
+    let multiplier = if s.ends_with('d') {
         24 * 60 * 60
-    } else if s.ends_with("m") {
+    } else if s.ends_with('m') {
         30 * 24 * 60 * 60
-    } else if s.ends_with("y") {
+    } else if s.ends_with('y') {
         365 * 24 * 60 * 60
     } else {
         return Err(format!(

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -42,7 +42,7 @@ impl Server {
         let (tx_new_thread, rx_new_thread) = chan::unbounded();
         let (tx_done_thread, rx_done_thread) = chan::unbounded();
         let logger2 = logger.clone();
-        let _joiner = Async::run(&logger, move || {
+        let _joiner = Async::run(logger, move || {
             join_continuously(rx_new_thread, rx_done_thread, &logger2)
         });
 
@@ -50,7 +50,7 @@ impl Server {
             let tx_done_thread = tx_done_thread.clone();
             match listener.accept() {
                 Ok(connection) => {
-                    self.handle_client(connection, tx_new_thread.clone(), tx_done_thread, &logger)
+                    self.handle_client(connection, tx_new_thread.clone(), tx_done_thread, logger)
                 }
                 Err(accept_err) => {
                     info!(logger, "Failed accepting a client connection"; "accept_error" => format!("{:?}", accept_err));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,7 @@
 // I don’t think return, .into() is clearer than ?, sorry
 #![allow(clippy::try_err)]
 // triggered by select (TODO: fixed in crossbeam_channel 0.5)
-#![allow(clippy::drop_copy, clippy::zero_ptr)]
-// Remove clippy checks for stuff that is not even in stable yet (ugh)
-#![allow(clippy::match_like_matches_macro)]
+#![allow(dropping_copy_types, clippy::zero_ptr)]
 
 #[macro_use]
 extern crate structopt;
@@ -106,7 +104,7 @@ pub struct NixFile(AbsPathBuf);
 impl NixFile {
     /// Absolute path of this file.
     pub fn as_absolute_path(&self) -> &Path {
-        &self.0.as_path()
+        self.0.as_path()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn find_nix_file(shellfile: &Path) -> Result<NixFile, ExitError> {
 }
 
 fn create_project(paths: &constants::Paths, shell_nix: NixFile) -> Result<Project, ExitError> {
-    Project::new(shell_nix, &paths.gc_root_dir(), paths.cas_store().clone()).map_err(|err| {
+    Project::new(shell_nix, paths.gc_root_dir(), paths.cas_store().clone()).map_err(|err| {
         ExitError::temporary(anyhow::anyhow!(err).context("Could not set up project paths"))
     })
 }
@@ -186,8 +186,8 @@ mod tests {
 
         let out = std::process::Command::new("nix-instantiate")
             // we can’t assume to have a <nixpkgs>, so use bogus-nixpkgs
-            .args(&["-I", &format!("nixpkgs={}", nixpkgs)])
-            .args(&["--expr", ops::TRIVIAL_SHELL_SRC])
+            .args(["-I", &format!("nixpkgs={}", nixpkgs)])
+            .args(["--expr", ops::TRIVIAL_SHELL_SRC])
             .output()?;
         assert!(
             out.status.success(),

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -218,7 +218,7 @@ impl<'a> CallOpts<'a> {
         T: Send + serde::de::DeserializeOwned,
     {
         let mut cmd = Command::new("nix-instantiate");
-        cmd.args(&["--eval", "--json", "--strict"]);
+        cmd.args(["--eval", "--json", "--strict"]);
         cmd.args(self.command_arguments());
         self.execute(cmd, move |stdout_handle| {
             serde_json::from_reader::<_, T>(stdout_handle)
@@ -330,7 +330,7 @@ impl<'a> CallOpts<'a> {
         let mut cmd = Command::new("nix-build");
 
         // Create a gc root to the build output
-        cmd.args(&[
+        cmd.args([
             OsStr::new("--out-link"),
             gc_root_dir.path().join(Path::new("result")).as_os_str(),
         ]);

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -91,7 +91,7 @@ pub fn daemon(opts: crate::cli::DaemonOptions, logger: &slog::Logger) -> Result<
         paths.gc_root_dir(),
         paths.cas_store().clone(),
         user,
-        &logger,
+        logger,
     )?;
     build_handle
         .join()
@@ -345,7 +345,7 @@ pub fn shell(project: Project, opts: ShellOptions, logger: &slog::Logger) -> Res
 
     debug!(logger, "bash_cmd : {:?}", bash_cmd);
     let status = bash_cmd
-        .args(&[
+        .args([
             OsStr::new("-c"),
             OsStr::new(
                 "exec \"$1\" internal start-user-shell --shell-path=\"$2\" --shell-file=\"$3\"",
@@ -525,7 +525,7 @@ PS1="(lorri) $PS1"
 "#,
                 )
                 .expect("failed to write bash init script");
-            cmd.args(&[
+            cmd.args([
                 "--rcfile",
                 rcfile
                     .as_path()
@@ -691,7 +691,7 @@ pub fn stream_events(kind: EventKind, logger: &slog::Logger) -> Result<(), ExitE
                             )),
                         )
                             .expect("couldn't serialize event");
-                        write!(std::io::stdout(), "\n").expect("couldn't serialize event");
+                        writeln!(std::io::stdout()).expect("couldn't serialize event");
                         std::io::stdout().flush().expect("couldn't flush serialized event");
                     }
                     _ => (),
@@ -807,7 +807,7 @@ pub fn upgrade(
             UpgradeSource::Local(ref p) => println!("Upgrading from local path: {}", p.display()),
         }
 
-        let mut expr = nix::CallOpts::file(&upgrade_expr.as_path());
+        let mut expr = nix::CallOpts::file(upgrade_expr.as_path());
 
         match src {
             UpgradeSource::Branch(b) => {

--- a/src/pathreduction.rs
+++ b/src/pathreduction.rs
@@ -131,7 +131,7 @@ fn reduce_channel_path(path: &WatchPathBuf) -> ReductionOp {
     // the directory containing the swapped channel symlink.
     let canonical_channel_location = channel_root_path.canonicalize().unwrap();
     let canonical_path_location = path.as_ref().canonicalize().unwrap();
-    if canonical_path_location.starts_with(&canonical_channel_location) {
+    if canonical_path_location.starts_with(canonical_channel_location) {
         let reduce_to = channel_root_path
             .parent()
             .expect("expected /nix/var/nix/profiles/per-user/root/channels")

--- a/src/project.rs
+++ b/src/project.rs
@@ -111,11 +111,11 @@ where {
         let store_path = &path.path;
 
         debug!(logger, "adding root"; "from" => store_path.as_path().to_str(), "to" => self.shell_gc_root().display());
-        std::fs::remove_file(&self.shell_gc_root())
-            .or_else(|e| AddRootError::remove(e, &self.shell_gc_root().as_path()))?;
+        std::fs::remove_file(self.shell_gc_root())
+            .or_else(|e| AddRootError::remove(e, self.shell_gc_root().as_path()))?;
 
         // the forward GC root that points from the store path to our cache gc_roots dir
-        std::os::unix::fs::symlink(store_path.as_path(), &self.shell_gc_root()).map_err(|e| {
+        std::os::unix::fs::symlink(store_path.as_path(), self.shell_gc_root()).map_err(|e| {
             AddRootError::symlink(e, store_path.as_path(), self.shell_gc_root().as_path())
         })?;
 
@@ -135,7 +135,7 @@ where {
         // but we can create it for older nix versions (it’s root but `rwxrwxrwx`)
         // Newer nix versions make the directory `rwxr-xr-x`, meaning we need the user to intervene.
         if !nix_gc_root_user_dir.as_path().is_dir() {
-            let meta = std::fs::metadata(&nix_gc_root_user_dir_root.as_path()).map_err(|source| {
+            let meta = std::fs::metadata(nix_gc_root_user_dir_root.as_path()).map_err(|source| {
                 AddRootError {
                     source,
                     msg: format!("Cannot stat user roots directory for permission to create a new lorri user dir: {}", nix_gc_root_user_dir_root.display()),
@@ -144,7 +144,7 @@ where {
 
             // check whether we are allowed to create the directory
             if 0 != (meta.permissions().mode() & nix::libc::S_IWOTH) {
-                std::fs::create_dir_all(&nix_gc_root_user_dir.as_path()).map_err(|source| {
+                std::fs::create_dir_all(nix_gc_root_user_dir.as_path()).map_err(|source| {
                     AddRootError {
                         source,
                         msg: format!(
@@ -180,15 +180,15 @@ where {
             nix_gc_root_user_dir.join(format!("{}-{}", self.hash(), "shell_gc_root"));
 
         debug!(logger, "connecting root"; "from" => self.shell_gc_root().display(), "to" => nix_gc_root_user_dir_root.display());
-        std::fs::remove_file(&nix_gc_root_user_dir_root.as_path())
-            .or_else(|err| AddRootError::remove(err, &nix_gc_root_user_dir_root.as_path()))?;
+        std::fs::remove_file(nix_gc_root_user_dir_root.as_path())
+            .or_else(|err| AddRootError::remove(err, nix_gc_root_user_dir_root.as_path()))?;
 
-        std::os::unix::fs::symlink(&self.shell_gc_root(), &nix_gc_root_user_dir_root.as_path())
+        std::os::unix::fs::symlink(self.shell_gc_root(), nix_gc_root_user_dir_root.as_path())
             .map_err(|e| {
                 AddRootError::symlink(
                     e,
                     self.shell_gc_root().as_path(),
-                    &nix_gc_root_user_dir_root.as_path(),
+                    nix_gc_root_user_dir_root.as_path(),
                 )
             })?;
 

--- a/src/run_async.rs
+++ b/src/run_async.rs
@@ -38,7 +38,7 @@ impl<Res: Send + 'static> Async<Res> {
         F: std::panic::UnwindSafe,
         F: Send + 'static,
     {
-        Self::run_inner(&logger, f, false)
+        Self::run_inner(logger, f, false)
     }
 
     /// Create a new Async that runs a function in a thread.

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -74,7 +74,7 @@ impl<Err> Pool<Err> {
         let tx = self.tx.clone();
         let handle = builder.spawn(move || {
             let thread_id = thread::current().id();
-            let cause = match std::panic::catch_unwind(|| f()) {
+            let cause = match std::panic::catch_unwind(f) {
                 Ok(res) => Cause::Natural(res),
                 Err(panic) => Cause::Paniced(panic),
             };

--- a/tests/integration/direnvtestcase.rs
+++ b/tests/integration/direnvtestcase.rs
@@ -76,7 +76,7 @@ impl DirenvTestCase {
         }
 
         let mut env = self.direnv_cmd();
-        env.args(&["export", "json"]);
+        env.args(["export", "json"]);
         let result = env.output().expect("Failed to run direnv export json");
         if !result.status.success() {
             println!("stderr: {}", String::from_utf8_lossy(&result.stderr));
@@ -95,9 +95,9 @@ impl DirenvTestCase {
         d.env_remove("DIRENV_MTIME");
         d.env_remove("DIRENV_WATCHES");
         d.env_remove("DIRENV_DIFF");
-        d.env("DIRENV_CONFIG", &self.projectdir.path());
-        d.env("XDG_CONFIG_HOME", &self.projectdir.path());
-        d.current_dir(&self.projectdir.path());
+        d.env("DIRENV_CONFIG", self.projectdir.path());
+        d.env("XDG_CONFIG_HOME", self.projectdir.path());
+        d.current_dir(self.projectdir.path());
 
         d
     }
@@ -116,9 +116,9 @@ impl DirenvEnv {
     /// Makes asserts nicer, like:
     ///
     ///    assert!(env.get_env("foo"), Value("bar"));
-    pub fn get_env<'a, 'b>(&'a self, key: &'b str) -> DirenvValue {
+    pub fn get_env(&self, key: &str) -> DirenvValue {
         match self.0.get(key) {
-            Some(Some(val)) => DirenvValue::Value(&val),
+            Some(Some(val)) => DirenvValue::Value(val),
             Some(None) => DirenvValue::Unset,
             None => DirenvValue::NotSet,
         }
@@ -130,7 +130,7 @@ impl DirenvEnv {
         F: Fn(&str) -> bool,
     {
         let mut new = self.0.to_owned();
-        new.retain(|k, _| f(&k));
+        new.retain(|k, _| f(k));
         new
     }
 }

--- a/tests/integration/gc.rs
+++ b/tests/integration/gc.rs
@@ -43,7 +43,7 @@ derivation {
     )
     .expect("writing shell.nix");
     std::fs::write(
-        &project.join("builder.sh"),
+        project.join("builder.sh"),
         r#"
 #!/bin/sh
     "#,
@@ -53,14 +53,14 @@ derivation {
     let home = testdir.path().join("home");
     std::fs::create_dir(&home).expect("mkdir home");
     let home = home.canonicalize().expect("canonicalize home");
-    std::env::set_var("HOME", &home);
+    std::env::set_var("HOME", home);
     std::env::remove_var("XDG_CONFIG_HOME");
     std::env::remove_var("XDG_CACHE_HOME");
     std::env::set_current_dir(&project).expect("cd");
     // build the project
     assert!(dbg!(run_lorri(vec!["shell", "--shell-file", "shell.nix"]))
         .expect("running lorri shell")
-        .contains(&"done"));
+        .contains("done"));
 
     //look for the gc root
     let pd = ProjectDirs::from("com.github.nix-community.lorri", "lorri", "lorri")
@@ -70,9 +70,8 @@ derivation {
         .canonicalize()
         .expect("canonicalize gc_root dir")
         .join("gc_roots");
-    let mut subdirs = std::fs::read_dir(&gc_roots)
+    let mut subdirs = std::fs::read_dir(gc_roots)
         .expect("readdir")
-        .into_iter()
         .collect::<Vec<_>>();
     assert_eq!(
         subdirs.len(),
@@ -83,7 +82,7 @@ derivation {
     let subdir = subdirs.drain(..).next().unwrap().expect("direntry").path();
     let gc_root_dir = subdir.join("gc_root");
     let root = gc_root_dir.join("shell_gc_root");
-    assert!(std::fs::read_link(&root)
+    assert!(std::fs::read_link(root)
         .expect("readlink gc root")
         .starts_with("/nix/store"));
 
@@ -116,7 +115,7 @@ derivation {
     std::fs::rename(&backup_file, &nix_file).expect("rename back");
     assert!(dbg!(run_lorri(vec!["shell", "--shell-file", "shell.nix"]))
         .expect("running lorri shell")
-        .contains(&"done"));
+        .contains("done"));
     // everything back to normal
     let out = run_lorri(vec!["gc", "info"]).unwrap();
     assert!(dbg!(&out).contains(&dbg!(subdir.display().to_string())));

--- a/tests/integration/trivial.rs
+++ b/tests/integration/trivial.rs
@@ -12,8 +12,8 @@ fn trivial() -> std::io::Result<()> {
         testcase.cachedir.path().display(),
         std::str::from_utf8(
             &std::process::Command::new("ls")
-                .args(&["-la", "--recursive"])
-                .args(&[testcase.cachedir.path().as_os_str()])
+                .args(["-la", "--recursive"])
+                .args([testcase.cachedir.path().as_os_str()])
                 .output()?
                 .stdout
         )

--- a/tests/shell/main.rs
+++ b/tests/shell/main.rs
@@ -32,7 +32,7 @@ fn loads_env() {
 
     // Launch as a real user
     let res = Command::new(cargo_bin("lorri"))
-        .args(&[
+        .args([
             "shell",
             "--shell-file",
             project
@@ -51,7 +51,7 @@ fn loads_env() {
 
     let output = ops::bash_cmd(build(&project, &logger), &project.cas, &logger)
         .unwrap()
-        .args(&["-c", "echo $MY_ENV_VAR"])
+        .args(["-c", "echo $MY_ENV_VAR"])
         .output()
         .expect("failed to run shell");
 


### PR DESCRIPTION
Fixing several clippy lints that would otherwise be flyspecks distracting from the focus of future PRs.
