### PR TITLE
fix(logging): always log to stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
         // This logger is asynchronous. It is guaranteed to be flushed upon destruction. By tying
         // its lifetime to this smaller scope, we ensure that it is destroyed before
         // 'std::process::exit' gets called.
-        let logger = logging::root(verbosity, &opts.command);
+        let logger = logging::root(verbosity);
         debug!(logger, "input options"; "options" => ?opts);
 
         match run_command(&logger, opts) {


### PR DESCRIPTION
It makes about ~zero sense to log to stdout. Why do people always do this.



<!--
Explain the approach you took to resolving the issue and provide necessary context.
There is no need to go into a lot of detail here: instead, try to make each commit self-explanatory and write good commit messages.
-->

- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)
