### PR TITLE
Update flake compatibility shim for nix > 2.7

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,12 @@
     # Find the current version number with `git log --pretty=%h | wc -l`
     entries = [
       {
+        version = 1024;
+        changes = ''
+          Update the flake compatibility shim to work with nix > 2.7.
+        '';
+      }
+      {
         version = 951;
         changes = ''
           Provide a better error message when the user tries to use flakes,

--- a/src/flake-compat-shell.nix
+++ b/src/flake-compat-shell.nix
@@ -1,3 +1,3 @@
 { system ? builtins.currentSystem }:
 
-(builtins.getFlake (toString ./.)).devShell.${system}
+(builtins.getFlake (toString ./.)).devShells.${system}.default


### PR DESCRIPTION
Since nix 2.7, the correct flake attribute is `devShells.<system>.<name>`, with "default" being a typical value for `<name>`.

release notes: https://nixos.org/manual/nix/stable/release-notes/rl-2.7

- [X] Amended the changelog in `release.nix` (see `release.nix` for instructions)
