### PR TITLE
Migrate to clap 4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -50,17 +90,6 @@ dependencies = [
  "rustix",
  "tempfile",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -110,18 +139,49 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.2.1",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "ctrlc"
@@ -261,21 +321,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -309,10 +357,16 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -381,6 +435,7 @@ dependencies = [
  "anyhow",
  "atomicwrites",
  "backtrace",
+ "clap",
  "ctrlc",
  "directories",
  "fastrand",
@@ -396,7 +451,6 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-term",
- "structopt",
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
@@ -538,15 +592,6 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
@@ -556,20 +601,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
- "proc-macro2 1.0.93",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -687,9 +723,9 @@ version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.35",
- "syn 2.0.98",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -744,42 +780,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
-dependencies = [
- "clap",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
-dependencies = [
- "heck",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid",
-]
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -787,8 +790,8 @@ version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -818,15 +821,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,9 +844,9 @@ version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.35",
- "syn 2.0.98",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -861,9 +855,9 @@ version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.35",
- "syn 2.0.98",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -930,9 +924,9 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.35",
- "syn 2.0.98",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -942,40 +936,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
 name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vec1"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab68b56840f69efb0fefbe3ab6661499217ffdc58e2eef7c3f6f69835386322"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -156,28 +156,116 @@ rec {
         };
         resolvedDefaultFeatures = [ "perf-literal" "std" ];
       };
-      "ansi_term" = rec {
-        crateName = "ansi_term";
-        version = "0.12.1";
-        edition = "2015";
-        sha256 = "1ljmkbilxgmhavxvxqa7qvm6f3fjggi7q2l3a72q9x0cxjvrnanm";
-        authors = [
-          "ogham@bsago.me"
-          "Ryan Scheel (Havvy) <ryan.havvy@gmail.com>"
-          "Josh Triplett <josh@joshtriplett.org>"
-        ];
+      "anstream" = rec {
+        crateName = "anstream";
+        version = "0.6.18";
+        edition = "2021";
+        sha256 = "16sjk4x3ns2c3ya1x28a44kh6p47c7vhk27251i015hik1lm7k4a";
         dependencies = [
           {
-            name = "winapi";
-            packageId = "winapi";
-            target = { target, features }: ("windows" == target."os" or null);
-            features = [ "consoleapi" "errhandlingapi" "fileapi" "handleapi" "processenv" ];
+            name = "anstyle";
+            packageId = "anstyle";
+          }
+          {
+            name = "anstyle-parse";
+            packageId = "anstyle-parse";
+          }
+          {
+            name = "anstyle-query";
+            packageId = "anstyle-query";
+            optional = true;
+          }
+          {
+            name = "anstyle-wincon";
+            packageId = "anstyle-wincon";
+            optional = true;
+            target = { target, features }: (target."windows" or false);
+          }
+          {
+            name = "colorchoice";
+            packageId = "colorchoice";
+          }
+          {
+            name = "is_terminal_polyfill";
+            packageId = "is_terminal_polyfill";
+          }
+          {
+            name = "utf8parse";
+            packageId = "utf8parse";
           }
         ];
         features = {
-          "derive_serde_style" = [ "serde" ];
-          "serde" = [ "dep:serde" ];
+          "auto" = [ "dep:anstyle-query" ];
+          "default" = [ "auto" "wincon" ];
+          "wincon" = [ "dep:anstyle-wincon" ];
         };
+        resolvedDefaultFeatures = [ "auto" "default" "wincon" ];
+      };
+      "anstyle" = rec {
+        crateName = "anstyle";
+        version = "1.0.10";
+        edition = "2021";
+        sha256 = "1yai2vppmd7zlvlrp9grwll60knrmscalf8l2qpfz8b7y5lkpk2m";
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
+      };
+      "anstyle-parse" = rec {
+        crateName = "anstyle-parse";
+        version = "0.2.6";
+        edition = "2021";
+        sha256 = "1acqayy22fwzsrvr6n0lz6a4zvjjcvgr5sm941m7m0b2fr81cb9v";
+        libName = "anstyle_parse";
+        dependencies = [
+          {
+            name = "utf8parse";
+            packageId = "utf8parse";
+            optional = true;
+          }
+        ];
+        features = {
+          "core" = [ "dep:arrayvec" ];
+          "default" = [ "utf8" ];
+          "utf8" = [ "dep:utf8parse" ];
+        };
+        resolvedDefaultFeatures = [ "default" "utf8" ];
+      };
+      "anstyle-query" = rec {
+        crateName = "anstyle-query";
+        version = "1.1.2";
+        edition = "2021";
+        sha256 = "036nm3lkyk43xbps1yql3583fp4hg3b1600is7mcyxs1gzrpm53r";
+        libName = "anstyle_query";
+        dependencies = [
+          {
+            name = "windows-sys";
+            packageId = "windows-sys 0.59.0";
+            target = { target, features }: (target."windows" or false);
+            features = [ "Win32_System_Console" "Win32_Foundation" ];
+          }
+        ];
+
+      };
+      "anstyle-wincon" = rec {
+        crateName = "anstyle-wincon";
+        version = "3.0.6";
+        edition = "2021";
+        sha256 = "099ir0w3lbpsp1nxdzbf4anq98ww8ykyc9pd1g03xgkj1v7dn291";
+        libName = "anstyle_wincon";
+        dependencies = [
+          {
+            name = "anstyle";
+            packageId = "anstyle";
+          }
+          {
+            name = "windows-sys";
+            packageId = "windows-sys 0.59.0";
+            target = { target, features }: (target."windows" or false);
+            features = [ "Win32_System_Console" "Win32_Foundation" ];
+          }
+        ];
+
       };
       "anyhow" = rec {
         crateName = "anyhow";
@@ -217,35 +305,6 @@ rec {
             packageId = "windows-sys 0.52.0";
             target = { target, features }: (target."windows" or false);
             features = [ "Win32_Foundation" "Win32_Storage_FileSystem" ];
-          }
-        ];
-
-      };
-      "atty" = rec {
-        crateName = "atty";
-        version = "0.2.14";
-        edition = "2015";
-        sha256 = "1s7yslcs6a28c5vz7jwj63lkfgyx8mx99fdirlhi9lbhhzhrpcyr";
-        authors = [
-          "softprops <d.tangren@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "hermit-abi";
-            packageId = "hermit-abi 0.1.19";
-            target = { target, features }: ("hermit" == target."os" or null);
-          }
-          {
-            name = "libc";
-            packageId = "libc";
-            usesDefaultFeatures = false;
-            target = { target, features }: (target."unix" or false);
-          }
-          {
-            name = "winapi";
-            packageId = "winapi";
-            target = { target, features }: (target."windows" or false);
-            features = [ "consoleapi" "processenv" "minwinbase" "minwindef" "winbase" ];
           }
         ];
 
@@ -379,63 +438,130 @@ rec {
       };
       "clap" = rec {
         crateName = "clap";
-        version = "2.34.0";
-        edition = "2018";
-        sha256 = "071q5d8jfwbazi6zhik9xwpacx5i6kb2vkzy060vhf0c3120aqd0";
-        authors = [
-          "Kevin K. <kbknapp@gmail.com>"
-        ];
+        version = "4.5.30";
+        edition = "2021";
+        crateBin = [];
+        sha256 = "0vcyrn4ymq2gd56sl3xnfki8q8llg64sj3rj3qx33mgsf66v3dwj";
         dependencies = [
           {
-            name = "ansi_term";
-            packageId = "ansi_term";
-            optional = true;
-            target = { target, features }: (!(target."windows" or false));
+            name = "clap_builder";
+            packageId = "clap_builder";
+            usesDefaultFeatures = false;
           }
           {
-            name = "atty";
-            packageId = "atty";
+            name = "clap_derive";
+            packageId = "clap_derive";
+            optional = true;
+          }
+        ];
+        features = {
+          "cargo" = [ "clap_builder/cargo" ];
+          "color" = [ "clap_builder/color" ];
+          "debug" = [ "clap_builder/debug" "clap_derive?/debug" ];
+          "default" = [ "std" "color" "help" "usage" "error-context" "suggestions" ];
+          "deprecated" = [ "clap_builder/deprecated" "clap_derive?/deprecated" ];
+          "derive" = [ "dep:clap_derive" ];
+          "env" = [ "clap_builder/env" ];
+          "error-context" = [ "clap_builder/error-context" ];
+          "help" = [ "clap_builder/help" ];
+          "std" = [ "clap_builder/std" ];
+          "string" = [ "clap_builder/string" ];
+          "suggestions" = [ "clap_builder/suggestions" ];
+          "unicode" = [ "clap_builder/unicode" ];
+          "unstable-doc" = [ "clap_builder/unstable-doc" "derive" ];
+          "unstable-ext" = [ "clap_builder/unstable-ext" ];
+          "unstable-markdown" = [ "clap_derive/unstable-markdown" ];
+          "unstable-styles" = [ "clap_builder/unstable-styles" ];
+          "unstable-v5" = [ "clap_builder/unstable-v5" "clap_derive?/unstable-v5" "deprecated" ];
+          "usage" = [ "clap_builder/usage" ];
+          "wrap_help" = [ "clap_builder/wrap_help" ];
+        };
+        resolvedDefaultFeatures = [ "color" "default" "derive" "error-context" "help" "std" "suggestions" "usage" ];
+      };
+      "clap_builder" = rec {
+        crateName = "clap_builder";
+        version = "4.5.30";
+        edition = "2021";
+        sha256 = "0369xis2ar46icsaxqyy37976mlb62alzyx4j53k99vq2w3v4pd3";
+        dependencies = [
+          {
+            name = "anstream";
+            packageId = "anstream";
             optional = true;
           }
           {
-            name = "bitflags";
-            packageId = "bitflags 1.2.1";
+            name = "anstyle";
+            packageId = "anstyle";
+          }
+          {
+            name = "clap_lex";
+            packageId = "clap_lex";
           }
           {
             name = "strsim";
             packageId = "strsim";
             optional = true;
           }
+        ];
+        features = {
+          "color" = [ "dep:anstream" ];
+          "debug" = [ "dep:backtrace" ];
+          "default" = [ "std" "color" "help" "usage" "error-context" "suggestions" ];
+          "std" = [ "anstyle/std" ];
+          "suggestions" = [ "dep:strsim" "error-context" ];
+          "unicode" = [ "dep:unicode-width" "dep:unicase" ];
+          "unstable-doc" = [ "cargo" "wrap_help" "env" "unicode" "string" "unstable-ext" ];
+          "unstable-styles" = [ "color" ];
+          "unstable-v5" = [ "deprecated" ];
+          "wrap_help" = [ "help" "dep:terminal_size" ];
+        };
+        resolvedDefaultFeatures = [ "color" "error-context" "help" "std" "suggestions" "usage" ];
+      };
+      "clap_derive" = rec {
+        crateName = "clap_derive";
+        version = "4.5.28";
+        edition = "2021";
+        sha256 = "1vgigkhljp3r8r5lwdrn1ij93nafmjwh8cx77nppb9plqsaysk5z";
+        procMacro = true;
+        dependencies = [
           {
-            name = "textwrap";
-            packageId = "textwrap";
+            name = "heck";
+            packageId = "heck";
           }
           {
-            name = "unicode-width";
-            packageId = "unicode-width";
+            name = "proc-macro2";
+            packageId = "proc-macro2";
           }
           {
-            name = "vec_map";
-            packageId = "vec_map";
-            optional = true;
+            name = "quote";
+            packageId = "quote";
+          }
+          {
+            name = "syn";
+            packageId = "syn";
+            features = [ "full" ];
           }
         ];
         features = {
-          "ansi_term" = [ "dep:ansi_term" ];
-          "atty" = [ "dep:atty" ];
-          "clippy" = [ "dep:clippy" ];
-          "color" = [ "ansi_term" "atty" ];
-          "default" = [ "suggestions" "color" "vec_map" ];
-          "doc" = [ "yaml" ];
-          "strsim" = [ "dep:strsim" ];
-          "suggestions" = [ "strsim" ];
-          "term_size" = [ "dep:term_size" ];
-          "vec_map" = [ "dep:vec_map" ];
-          "wrap_help" = [ "term_size" "textwrap/term_size" ];
-          "yaml" = [ "yaml-rust" ];
-          "yaml-rust" = [ "dep:yaml-rust" ];
+          "raw-deprecated" = [ "deprecated" ];
+          "unstable-markdown" = [ "dep:pulldown-cmark" "dep:anstyle" ];
+          "unstable-v5" = [ "deprecated" ];
         };
-        resolvedDefaultFeatures = [ "ansi_term" "atty" "color" "default" "no_cargo" "strsim" "suggestions" "vec_map" ];
+        resolvedDefaultFeatures = [ "default" ];
+      };
+      "clap_lex" = rec {
+        crateName = "clap_lex";
+        version = "0.7.4";
+        edition = "2021";
+        sha256 = "19nwfls5db269js5n822vkc8dw0wjq2h1wf0hgr06ld2g52d2spl";
+
+      };
+      "colorchoice" = rec {
+        crateName = "colorchoice";
+        version = "1.0.3";
+        edition = "2021";
+        sha256 = "1439m3r3jy3xqck8aa13q658visn71ki76qa93cy55wkmalwlqsv";
+
       };
       "ctrlc" = rec {
         crateName = "ctrlc";
@@ -860,44 +986,12 @@ rec {
       };
       "heck" = rec {
         crateName = "heck";
-        version = "0.3.3";
-        edition = "2018";
-        sha256 = "0b0kkr790p66lvzn9nsmfjvydrbmh9z5gb664jchwgw64vxiwqkd";
-        authors = [
-          "Without Boats <woboats@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "unicode-segmentation";
-            packageId = "unicode-segmentation";
-          }
-        ];
+        version = "0.5.0";
+        edition = "2021";
+        sha256 = "1sjmpsdl8czyh9ywl3qcsfsq9a307dg4ni2vnlwgnzzqhc4y0113";
 
       };
-      "hermit-abi 0.1.19" = rec {
-        crateName = "hermit-abi";
-        version = "0.1.19";
-        edition = "2018";
-        sha256 = "0cxcm8093nf5fyn114w8vxbrbcyvv91d4015rdnlgfll7cs6gd32";
-        libName = "hermit_abi";
-        authors = [
-          "Stefan Lankes"
-        ];
-        dependencies = [
-          {
-            name = "libc";
-            packageId = "libc";
-            usesDefaultFeatures = false;
-          }
-        ];
-        features = {
-          "compiler_builtins" = [ "dep:compiler_builtins" ];
-          "core" = [ "dep:core" ];
-          "rustc-dep-of-std" = [ "core" "compiler_builtins/rustc-dep-of-std" "libc/rustc-dep-of-std" ];
-        };
-        resolvedDefaultFeatures = [ "default" ];
-      };
-      "hermit-abi 0.3.9" = rec {
+      "hermit-abi" = rec {
         crateName = "hermit-abi";
         version = "0.3.9";
         edition = "2021";
@@ -976,7 +1070,7 @@ rec {
         dependencies = [
           {
             name = "hermit-abi";
-            packageId = "hermit-abi 0.3.9";
+            packageId = "hermit-abi";
             target = { target, features }: ("hermit" == target."os" or null);
           }
           {
@@ -999,6 +1093,15 @@ rec {
           }
         ];
 
+      };
+      "is_terminal_polyfill" = rec {
+        crateName = "is_terminal_polyfill";
+        version = "1.70.1";
+        edition = "2021";
+        sha256 = "1kwfgglh91z33kl0w5i338mfpa3zs0hidq5j4ny4rmjwrikchhvr";
+        features = {
+        };
+        resolvedDefaultFeatures = [ "default" ];
       };
       "itoa" = rec {
         crateName = "itoa";
@@ -1178,6 +1281,11 @@ rec {
             packageId = "backtrace";
           }
           {
+            name = "clap";
+            packageId = "clap";
+            features = [ "derive" "error-context" ];
+          }
+          {
             name = "ctrlc";
             packageId = "ctrlc";
             features = [ "termination" ];
@@ -1243,11 +1351,6 @@ rec {
           {
             name = "slog-term";
             packageId = "slog-term";
-          }
-          {
-            name = "structopt";
-            packageId = "structopt";
-            features = [ "suggestions" "color" "no_cargo" ];
           }
           {
             name = "tempfile";
@@ -1714,27 +1817,7 @@ rec {
           "std" = [ "alloc" ];
         };
       };
-      "proc-macro2 0.4.30" = rec {
-        crateName = "proc-macro2";
-        version = "0.4.30";
-        edition = "2015";
-        sha256 = "0nd71fl24sys066jrha6j7i34nfkjv44yzw8yww9742wmc8j0gfg";
-        libName = "proc_macro2";
-        authors = [
-          "Alex Crichton <alex@alexcrichton.com>"
-        ];
-        dependencies = [
-          {
-            name = "unicode-xid";
-            packageId = "unicode-xid";
-          }
-        ];
-        features = {
-          "default" = [ "proc-macro" ];
-        };
-        resolvedDefaultFeatures = [ "default" "proc-macro" ];
-      };
-      "proc-macro2 1.0.93" = rec {
+      "proc-macro2" = rec {
         crateName = "proc-macro2";
         version = "1.0.93";
         edition = "2021";
@@ -1755,28 +1838,7 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "proc-macro" ];
       };
-      "quote 0.6.13" = rec {
-        crateName = "quote";
-        version = "0.6.13";
-        edition = "2015";
-        sha256 = "1qgqq48jymp5h4y082aanf25hrw6bpb678xh3zw993qfhxmkpqkc";
-        authors = [
-          "David Tolnay <dtolnay@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "proc-macro2";
-            packageId = "proc-macro2 0.4.30";
-            usesDefaultFeatures = false;
-          }
-        ];
-        features = {
-          "default" = [ "proc-macro" ];
-          "proc-macro" = [ "proc-macro2/proc-macro" ];
-        };
-        resolvedDefaultFeatures = [ "default" "proc-macro" ];
-      };
-      "quote 1.0.35" = rec {
+      "quote" = rec {
         crateName = "quote";
         version = "1.0.35";
         edition = "2018";
@@ -1787,7 +1849,7 @@ rec {
         dependencies = [
           {
             name = "proc-macro2";
-            packageId = "proc-macro2 1.0.93";
+            packageId = "proc-macro2";
             usesDefaultFeatures = false;
           }
         ];
@@ -2234,19 +2296,19 @@ rec {
         dependencies = [
           {
             name = "proc-macro2";
-            packageId = "proc-macro2 1.0.93";
+            packageId = "proc-macro2";
             usesDefaultFeatures = false;
             features = [ "proc-macro" ];
           }
           {
             name = "quote";
-            packageId = "quote 1.0.35";
+            packageId = "quote";
             usesDefaultFeatures = false;
             features = [ "proc-macro" ];
           }
           {
             name = "syn";
-            packageId = "syn 2.0.98";
+            packageId = "syn";
             usesDefaultFeatures = false;
             features = [ "clone-impls" "derive" "parsing" "printing" "proc-macro" ];
           }
@@ -2401,115 +2463,16 @@ rec {
       };
       "strsim" = rec {
         crateName = "strsim";
-        version = "0.8.0";
+        version = "0.11.1";
         edition = "2015";
-        sha256 = "0sjsm7hrvjdifz661pjxq5w4hf190hx53fra8dfvamacvff139cf";
+        sha256 = "0kzvqlw8hxqb7y598w1s0hxlnmi84sg5vsipp3yg5na5d1rvba3x";
         authors = [
-          "Danny Guo <dannyguo91@gmail.com>"
+          "Danny Guo <danny@dannyguo.com>"
+          "maxbachmann <oss@maxbachmann.de>"
         ];
 
       };
-      "structopt" = rec {
-        crateName = "structopt";
-        version = "0.2.18";
-        edition = "2015";
-        sha256 = "1mvfv1l8vp3y402fkl2wcl34hi7gmr4bqha13dfz2xf3kjzwvhhn";
-        authors = [
-          "Guillaume Pinot <texitoi@texitoi.eu>"
-          "others"
-        ];
-        dependencies = [
-          {
-            name = "clap";
-            packageId = "clap";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "structopt-derive";
-            packageId = "structopt-derive";
-          }
-        ];
-        features = {
-          "color" = [ "clap/color" ];
-          "debug" = [ "clap/debug" ];
-          "default" = [ "clap/default" ];
-          "doc" = [ "clap/doc" ];
-          "lints" = [ "clap/lints" ];
-          "nightly" = [ "structopt-derive/nightly" ];
-          "no_cargo" = [ "clap/no_cargo" ];
-          "paw" = [ "structopt-derive/paw" ];
-          "suggestions" = [ "clap/suggestions" ];
-          "wrap_help" = [ "clap/wrap_help" ];
-          "yaml" = [ "clap/yaml" ];
-        };
-        resolvedDefaultFeatures = [ "color" "default" "no_cargo" "suggestions" ];
-      };
-      "structopt-derive" = rec {
-        crateName = "structopt-derive";
-        version = "0.2.18";
-        edition = "2015";
-        sha256 = "01sis9z5kqmyhvzbnmlzpdxcry99a0b9blypksgnhdsbm1hh40ak";
-        procMacro = true;
-        libName = "structopt_derive";
-        authors = [
-          "Guillaume Pinot <texitoi@texitoi.eu>"
-        ];
-        dependencies = [
-          {
-            name = "heck";
-            packageId = "heck";
-          }
-          {
-            name = "proc-macro2";
-            packageId = "proc-macro2 0.4.30";
-          }
-          {
-            name = "quote";
-            packageId = "quote 0.6.13";
-          }
-          {
-            name = "syn";
-            packageId = "syn 0.15.44";
-          }
-        ];
-        features = {
-          "nightly" = [ "proc-macro2/nightly" ];
-        };
-      };
-      "syn 0.15.44" = rec {
-        crateName = "syn";
-        version = "0.15.44";
-        edition = "2015";
-        sha256 = "1id5g6x6zihv3j7hwrw3m1jp636bg8dpi671r7zy3jvpkavb794w";
-        authors = [
-          "David Tolnay <dtolnay@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "proc-macro2";
-            packageId = "proc-macro2 0.4.30";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "quote";
-            packageId = "quote 0.6.13";
-            optional = true;
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "unicode-xid";
-            packageId = "unicode-xid";
-          }
-        ];
-        features = {
-          "default" = [ "derive" "parsing" "printing" "clone-impls" "proc-macro" ];
-          "printing" = [ "quote" ];
-          "proc-macro" = [ "proc-macro2/proc-macro" "quote/proc-macro" ];
-          "quote" = [ "dep:quote" ];
-        };
-        resolvedDefaultFeatures = [ "clone-impls" "default" "derive" "parsing" "printing" "proc-macro" "quote" ];
-      };
-      "syn 2.0.98" = rec {
+      "syn" = rec {
         crateName = "syn";
         version = "2.0.98";
         edition = "2021";
@@ -2520,12 +2483,12 @@ rec {
         dependencies = [
           {
             name = "proc-macro2";
-            packageId = "proc-macro2 1.0.93";
+            packageId = "proc-macro2";
             usesDefaultFeatures = false;
           }
           {
             name = "quote";
-            packageId = "quote 1.0.35";
+            packageId = "quote";
             optional = true;
             usesDefaultFeatures = false;
           }
@@ -2624,25 +2587,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" ];
       };
-      "textwrap" = rec {
-        crateName = "textwrap";
-        version = "0.11.0";
-        edition = "2015";
-        sha256 = "0q5hky03ik3y50s9sz25r438bc4nwhqc6dqwynv4wylc807n29nk";
-        authors = [
-          "Martin Geisler <martin@geisler.net>"
-        ];
-        dependencies = [
-          {
-            name = "unicode-width";
-            packageId = "unicode-width";
-          }
-        ];
-        features = {
-          "hyphenation" = [ "dep:hyphenation" ];
-          "term_size" = [ "dep:term_size" ];
-        };
-      };
       "thiserror 1.0.58" = rec {
         crateName = "thiserror";
         version = "1.0.58";
@@ -2691,15 +2635,15 @@ rec {
         dependencies = [
           {
             name = "proc-macro2";
-            packageId = "proc-macro2 1.0.93";
+            packageId = "proc-macro2";
           }
           {
             name = "quote";
-            packageId = "quote 1.0.35";
+            packageId = "quote";
           }
           {
             name = "syn";
-            packageId = "syn 2.0.98";
+            packageId = "syn";
           }
         ];
 
@@ -2717,15 +2661,15 @@ rec {
         dependencies = [
           {
             name = "proc-macro2";
-            packageId = "proc-macro2 1.0.93";
+            packageId = "proc-macro2";
           }
           {
             name = "quote";
-            packageId = "quote 1.0.35";
+            packageId = "quote";
           }
           {
             name = "syn";
-            packageId = "syn 2.0.98";
+            packageId = "syn";
           }
         ];
 
@@ -2980,15 +2924,15 @@ rec {
         dependencies = [
           {
             name = "proc-macro2";
-            packageId = "proc-macro2 1.0.93";
+            packageId = "proc-macro2";
           }
           {
             name = "quote";
-            packageId = "quote 1.0.35";
+            packageId = "quote";
           }
           {
             name = "syn";
-            packageId = "syn 2.0.98";
+            packageId = "syn";
             features = [ "full" ];
           }
         ];
@@ -3005,51 +2949,6 @@ rec {
         ];
 
       };
-      "unicode-segmentation" = rec {
-        crateName = "unicode-segmentation";
-        version = "1.11.0";
-        edition = "2018";
-        sha256 = "00kjpwp1g8fqm45drmwivlacn3y9jx73bvs09n6s3x73nqi7vj6l";
-        libName = "unicode_segmentation";
-        authors = [
-          "kwantam <kwantam@gmail.com>"
-          "Manish Goregaokar <manishsmail@gmail.com>"
-        ];
-        features = {
-        };
-      };
-      "unicode-width" = rec {
-        crateName = "unicode-width";
-        version = "0.1.11";
-        edition = "2015";
-        sha256 = "11ds4ydhg8g7l06rlmh712q41qsrd0j0h00n1jm74kww3kqk65z5";
-        libName = "unicode_width";
-        authors = [
-          "kwantam <kwantam@gmail.com>"
-          "Manish Goregaokar <manishsmail@gmail.com>"
-        ];
-        features = {
-          "compiler_builtins" = [ "dep:compiler_builtins" ];
-          "core" = [ "dep:core" ];
-          "rustc-dep-of-std" = [ "std" "core" "compiler_builtins" ];
-          "std" = [ "dep:std" ];
-        };
-        resolvedDefaultFeatures = [ "default" ];
-      };
-      "unicode-xid" = rec {
-        crateName = "unicode-xid";
-        version = "0.1.0";
-        edition = "2015";
-        sha256 = "1z57lqh4s18rr4x0j4fw4fmp9hf9346h0kmdgqsqx0fhjr3k0wpw";
-        libName = "unicode_xid";
-        authors = [
-          "erick.tryzelaar <erick.tryzelaar@gmail.com>"
-          "kwantam <kwantam@gmail.com>"
-        ];
-        features = {
-        };
-        resolvedDefaultFeatures = [ "default" ];
-      };
       "urlencoding" = rec {
         crateName = "urlencoding";
         version = "2.1.3";
@@ -3060,6 +2959,19 @@ rec {
           "Bertram Truong <b@bertramtruong.com>"
         ];
 
+      };
+      "utf8parse" = rec {
+        crateName = "utf8parse";
+        version = "0.2.2";
+        edition = "2018";
+        sha256 = "088807qwjq46azicqwbhlmzwrbkz7l4hpw43sdkdyyk524vdxaq6";
+        authors = [
+          "Joe Wilm <joe@jwilm.com>"
+          "Christian Duerr <contact@christianduerr.com>"
+        ];
+        features = {
+        };
+        resolvedDefaultFeatures = [ "default" ];
       };
       "vec1" = rec {
         crateName = "vec1";
@@ -3077,44 +2989,6 @@ rec {
           "smallvec_v1_" = [ "dep:smallvec_v1_" ];
         };
         resolvedDefaultFeatures = [ "default" "std" ];
-      };
-      "vec_map" = rec {
-        crateName = "vec_map";
-        version = "0.8.2";
-        edition = "2015";
-        sha256 = "1481w9g1dw9rxp3l6snkdqihzyrd2f8vispzqmwjwsdyhw8xzggi";
-        authors = [
-          "Alex Crichton <alex@alexcrichton.com>"
-          "Jorge Aparicio <japaricious@gmail.com>"
-          "Alexis Beingessner <a.beingessner@gmail.com>"
-          "Brian Anderson <>"
-          "tbu- <>"
-          "Manish Goregaokar <>"
-          "Aaron Turon <aturon@mozilla.com>"
-          "Adolfo Ochagavía <>"
-          "Niko Matsakis <>"
-          "Steven Fackler <>"
-          "Chase Southwood <csouth3@illinois.edu>"
-          "Eduard Burtescu <>"
-          "Florian Wilkens <>"
-          "Félix Raimundo <>"
-          "Tibor Benke <>"
-          "Markus Siemens <markus@m-siemens.de>"
-          "Josh Branchaud <jbranchaud@gmail.com>"
-          "Huon Wilson <dbau.pp@gmail.com>"
-          "Corey Farwell <coref@rwell.org>"
-          "Aaron Liblong <>"
-          "Nick Cameron <nrc@ncameron.org>"
-          "Patrick Walton <pcwalton@mimiga.net>"
-          "Felix S Klock II <>"
-          "Andrew Paseltiner <apaseltiner@gmail.com>"
-          "Sean McArthur <sean.monstar@gmail.com>"
-          "Vadim Petrochenkov <>"
-        ];
-        features = {
-          "eders" = [ "serde" ];
-          "serde" = [ "dep:serde" ];
-        };
       };
       "walkdir" = rec {
         crateName = "walkdir";
@@ -3200,7 +3074,7 @@ rec {
         features = {
           "debug" = [ "impl-debug" ];
         };
-        resolvedDefaultFeatures = [ "consoleapi" "errhandlingapi" "fileapi" "handleapi" "knownfolders" "minwinbase" "minwindef" "objbase" "processenv" "shlobj" "std" "sysinfoapi" "winbase" "wincon" "winerror" "winnt" ];
+        resolvedDefaultFeatures = [ "consoleapi" "errhandlingapi" "fileapi" "handleapi" "knownfolders" "minwindef" "objbase" "processenv" "shlobj" "std" "sysinfoapi" "winbase" "wincon" "winerror" "winnt" ];
       };
       "winapi-i686-pc-windows-gnu" = rec {
         crateName = "winapi-i686-pc-windows-gnu";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,7 @@ tempfile = "3.16.0"
 anyhow = "1.0.95"
 thiserror = "2.0.11"
 tokio = { features = ["rt", "rt-multi-thread", "macros", "net", "time", "io-util", "io-std", "sync", "process", "fs"], version = "1.43.0" }
-
-# TODO: update to 0.3
-structopt = { version = "0.2", default-features = true, features = ["suggestions", "color", "no_cargo"] }
+clap = { version = "4.5.30", features = ["derive", "error-context"] }
 
 # logging;
 slog = { version = "2.7.0", features = [

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,24 +8,26 @@
 //
 // See MAINTAINERS.md for details on internal and non-internal commands.
 
-use std::{convert::TryFrom, path::PathBuf, time::Duration};
-
-use structopt::clap;
+use std::{convert::TryFrom, path::PathBuf, str::FromStr, time::Duration};
 
 use crate::{project::ProjectFile, AbsDirPathBuf, AbsPathBuf, Installable};
+use clap::{
+    error::{ContextKind, ContextValue},
+    Parser, Subcommand,
+};
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "lorri")]
+#[derive(Parser, Debug)]
+#[command(name = "lorri", version)]
 /// Global arguments which set global program state. Most
 /// arguments will be to sub-commands.
 pub struct Arguments {
     /// Activate debug logging. Multiple occurrences are accepted for backwards compatibility, but
     /// have no effect. This will display all messages lorri logs.
-    #[structopt(short = "v", long = "verbose", parse(from_occurrences))]
+    #[arg(short, long, default_value_t = 0, required = false)]
     pub verbosity: u8,
 
     /// Sub-command to execute
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     pub command: Command,
 }
 
@@ -38,65 +40,52 @@ pub enum Verbosity {
     Debug,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 /// Sub-commands which lorri can execute
 pub enum Command {
     /// Emit shell script intended to be evaluated as part of direnv's .envrc, via: `eval "$(lorri
     /// direnv)"`
-    #[structopt(name = "direnv")]
     Direnv(DirenvOptions),
 
     /// Remove lorri garbage collection roots that point to removed shell.nix files
-    #[structopt(name = "gc")]
     Gc(GcOptions),
 
     /// Show information about a lorri project
-    #[structopt(name = "info")]
     Info(InfoOptions),
 
     /// Open a new project shell
-    #[structopt(name = "shell")]
     Shell(ShellOptions),
 
     /// Build project whenever an input file changes
-    #[structopt(name = "watch")]
     Watch(WatchOptions),
 
     /// Start the multi-project daemon. Replaces `lorri watch`
-    #[structopt(name = "daemon")]
     Daemon(DaemonOptions),
 
     /// Write bootstrap files to current directory to create a new lorri project
-    #[structopt(name = "init")]
     Init,
 
     /// Internal commands, only use to experiment with unstable features
-    #[structopt(name = "internal")]
     Internal {
         /// Sub-command to execute
-        #[structopt(subcommand)]
+        #[command(subcommand)]
         command: Internal_,
     },
 }
 
 /// Common options about the build source, defaults to `shell.nix`
-#[derive(StructOpt, Debug, Clone)]
+#[derive(Parser, Debug, Clone)]
 pub struct DefaultingSourceOptions {
     /// The .nix file in the current directory to use
-    #[structopt(long = "shell-file", parse(from_os_str))]
+    #[arg(long)]
     pub shell_file: Option<PathBuf>,
 
     /// The path to consider a flake source within
-    #[structopt(
-        long = "context",
-        parse(from_os_str),
-        default_value = ".",
-        conflicts_with = "nix_file"
-    )]
+    #[arg(long = "context", default_value = ".", conflicts_with = "shell_file")]
     pub context_dir: PathBuf,
 
     /// The installable descriptor for a flake
-    #[structopt(long = "flake", conflicts_with = "nix_file")]
+    #[arg(long, conflicts_with = "shell_file")]
     pub flake: Option<String>,
 }
 
@@ -104,10 +93,12 @@ fn from_current_dir(rel: &PathBuf) -> Result<AbsPathBuf, clap::Error> {
     AbsDirPathBuf::current_dir()?
         .relative_to(rel.clone())
         .map_err(|err| {
-            clap::Error::with_description(
-                &format!("could not make {:?} absolute: {:?}", rel, err),
-                clap::ErrorKind::ValueValidation,
-            )
+            let mut e = clap::error::Error::new(clap::error::ErrorKind::ValueValidation);
+            e.insert(
+                clap::error::ContextKind::InvalidValue,
+                ContextValue::String(format!("could not make {:?} absolute: {:?}", rel, err)),
+            );
+            e
         })
 }
 
@@ -116,21 +107,27 @@ impl TryFrom<DefaultingSourceOptions> for ProjectFile {
 
     fn try_from(opts: DefaultingSourceOptions) -> Result<Self, Self::Error> {
         match (opts.shell_file, opts.flake) {
-            (Some(_), Some(_)) => Err(clap::Error::with_description(
-                "cannot use nix-shell files and flakes together",
-                clap::ErrorKind::ArgumentConflict,
-            )),
+            (Some(_), Some(_)) => {
+                let mut e = clap::Error::new(clap::error::ErrorKind::ArgumentConflict);
+                e.insert(
+                    clap::error::ContextKind::Suggested,
+                    ContextValue::String(
+                        "cannot use nix-shell files and flakes together".to_string(),
+                    ),
+                );
+                Err(e)
+            }
             // XXX Consider more sophisticated default - e.g. first that exists: shell.nix, flake.nix, default.nix
             (None, None) => find_nix_file("shell.nix")
                 .or_else(|| find_nix_file("flake.nix"))
                 .or_else(|| find_nix_file("default.nix"))
-                .ok_or_else(|| clap::Error::with_description(
-                    &format!(
-                    "No default build sources found\n\
+                .ok_or_else(|| {
+                    let mut e = clap::error::Error::new(clap::error::ErrorKind::ValueValidation);
+                    e.insert(clap::error::ContextKind::Suggested, ContextValue::String(format!( "No default build sources found\n\
                     You can use a flake.nix file or the following minimal `shell.nix` to get started:\n\n\
-                    {}",
-                    TRIVIAL_SHELL_SRC
-                ), clap::ErrorKind::ValueValidation)),
+                    {}", TRIVIAL_SHELL_SRC)));
+                    e
+                }),
             (Some(shell), None) => Ok(ProjectFile::ShellNix(from_current_dir(&shell)?.into())),
             (None, Some(flake)) => Ok(ProjectFile::FlakeNix(Installable {
                 context: from_current_dir(&opts.context_dir)?,
@@ -179,23 +176,18 @@ fn find_nix_file(shellfile: &str) -> Option<ProjectFile> {
 /// This version of the source options has no default value. That's on purpose: sometimes the user
 /// will have projects with multiple shell files. This way, they are forced to think about which shell
 /// file was causing problems when they submit a bug report.
-#[derive(StructOpt, Debug, Clone)]
+#[derive(Parser, Debug, Clone)]
 pub struct SourceOptions {
     /// The .nix file in the current directory to use
-    #[structopt(long = "shell-file", parse(from_os_str))]
+    #[arg(long)]
     pub shell_file: Option<PathBuf>,
 
     /// The path to consider a flake source within
-    #[structopt(
-        long = "context",
-        parse(from_os_str),
-        default_value = ".",
-        conflicts_with = "nix_file"
-    )]
+    #[arg(long = "context", default_value = ".", conflicts_with = "shell_file")]
     pub context_dir: PathBuf,
 
     /// The installable descriptor for a flake
-    #[structopt(long = "flake", conflicts_with = "nix_file")]
+    #[arg(long = "flake", conflicts_with = "shell_file")]
     pub flake: Option<String>,
 }
 
@@ -204,14 +196,25 @@ impl TryFrom<SourceOptions> for ProjectFile {
 
     fn try_from(opts: SourceOptions) -> Result<Self, Self::Error> {
         match (opts.shell_file, opts.flake) {
-            (Some(_), Some(_)) => Err(clap::Error::with_description(
-                "cannot use nix-shell files and flakes together",
-                clap::ErrorKind::ArgumentConflict,
-            )),
-            (None, None) => Err(clap::Error::with_description(
-                "either --shell-file or --flake is required",
-                clap::ErrorKind::MissingRequiredArgument,
-            )),
+            (Some(_), Some(_)) => {
+                let mut e = clap::error::Error::new(clap::error::ErrorKind::ArgumentConflict);
+                e.insert(
+                    ContextKind::InvalidValue,
+                    ContextValue::String(
+                        "cannot use nix-shell files and flakes together".to_string(),
+                    ),
+                );
+                Err(e)
+            }
+            (None, None) => {
+                let mut e =
+                    clap::error::Error::new(clap::error::ErrorKind::MissingRequiredArgument);
+                e.insert(
+                    ContextKind::SuggestedArg,
+                    ContextValue::String("either --shell-file or --flake is required".to_string()),
+                );
+                Err(e)
+            }
             (Some(shell), None) => Ok(ProjectFile::ShellNix(from_current_dir(&shell)?.into())),
             (None, Some(flake)) => Ok(ProjectFile::FlakeNix(Installable {
                 context: from_current_dir(&opts.context_dir)?,
@@ -222,18 +225,18 @@ impl TryFrom<SourceOptions> for ProjectFile {
 }
 
 /// Options for the `direnv` subcommand.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct DirenvOptions {
     #[allow(missing_docs)]
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub source: DefaultingSourceOptions,
 }
 
 /// Options for the `info` subcommand.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct InfoOptions {
     #[allow(missing_docs)]
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub source: SourceOptions,
 }
 
@@ -292,83 +295,78 @@ fn test_human_friendly_duration() {
 }
 
 /// Options for the `gc` subcommand.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct GcOptions {
     /// Machine readable output
-    #[structopt(long)]
+    #[arg(long)]
     pub json: bool,
 
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     /// Subcommand for lorri gc
     pub action: GcSubcommand,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Subcommand, Debug)]
 /// Subcommand for lorri gc
 pub enum GcSubcommand {
     /// Prints the gc roots that lorri created.
-    #[structopt(name = "info")]
     Info,
     /// Removes the gc roots associated to projects whose nix file vanished.
-    #[structopt(name = "rm")]
     Rm {
         /// Also delete the root associated with these shell files
-        #[structopt(long = "shell-file")]
+        #[arg(long)]
         shell_file: Vec<PathBuf>,
         /// Delete the root of all projects
-        #[structopt(long)]
+        #[arg(long)]
         all: bool,
         /// Also delete the root of projects that were last built before this amount of time, e.g. 30d.
-        #[structopt(long = "older-than", parse(try_from_str = "human_friendly_duration"))]
+        #[arg(long = "older-than", value_parser = clap::builder::ValueParser::new(human_friendly_duration))]
         older_than: Option<Duration>,
     },
 }
 
 /// Options for the `shell` subcommand.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct ShellOptions {
     // The source to build the environment from
     #[allow(missing_docs)]
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub source: DefaultingSourceOptions,
 
     /// If true, load environment from cache
-    #[structopt(long = "cached")]
+    #[arg(long)]
     pub cached: bool,
 }
 
 /// Options for the `internal start-user-shell` subcommand.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct StartUserShellOptions_ {
     /// The path of the parent shell's binary
-    #[structopt(long = "shell-path", parse(from_os_str))]
+    #[arg(long)]
     pub shell_path: PathBuf,
 
     // The source to build the environment from
     #[allow(missing_docs)]
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub source: DefaultingSourceOptions,
 }
 
 /// Options for the `watch` subcommand.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct WatchOptions {
     // The source to build the environment from
     #[allow(missing_docs)]
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub source: DefaultingSourceOptions,
     /// Exit after a the first build
-    #[structopt(long = "once")]
+    #[arg(long)]
     pub once: bool,
 }
 
 /// Options for the `daemon` subcommand
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct DaemonOptions {
-    #[structopt(
-        long = "extra-nix-options",
-        parse(try_from_str = "serde_json::from_str")
-    )]
+    #[arg(long)]
     /// JSON value of nix config options to add.
     /// Only a subset is supported:
     /// {
@@ -379,7 +377,7 @@ pub struct DaemonOptions {
 }
 
 /// The nix options we can parse as json string
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 // ATTN: If you modify this,
 // adjust the help text in DaemonOptions.extra_nix_options
 pub struct NixOptions {
@@ -389,15 +387,21 @@ pub struct NixOptions {
     pub substituters: Option<Vec<String>>,
 }
 
+impl FromStr for NixOptions {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
 /// Sub-commands which lorri can execute for internal features
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum Internal_ {
     /// (internal) Used internally by `lorri shell`
-    #[structopt(name = "start-user-shell")]
     StartUserShell_(StartUserShellOptions_),
 
     /// (plumbing) Tell the lorri daemon to care about the current directory's project
-    #[structopt(name = "ping")]
     Ping_(Ping_),
 
     /// (experimental) Ask the lorri daemon to report build events as they occur.
@@ -406,7 +410,6 @@ pub enum Internal_ {
     /// so if you want to use it in your scripts make sure you follow our changes.
     /// Once it stabilizes a bit more we will start mentioning changes in the changelog,
     /// and eventually ensure backwards compat.
-    #[structopt(name = "stream-events")]
     StreamEvents_(StreamEvents_),
 }
 
@@ -415,68 +418,63 @@ pub enum Internal_ {
 /// Pinging with a project tells the daemon that the project was recently interacted with.
 /// If the daemon has not been pinged for a project, it begins listening. If it does not
 /// get pinged for a long time, it may stop watching the project for changes.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct Ping_ {
     #[allow(missing_docs)]
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub source: DefaultingSourceOptions,
 }
 
 /// Stream events from the daemon.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct StreamEvents_ {
-    #[structopt(long, default_value = "all")]
+    #[arg(long, default_value = "all")]
     /// The kind of events to report
     pub kind: crate::ops::EventKind,
 }
 
 /// A stub struct to represent how what we want to upgrade to.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 #[structopt(name = "basic")]
 pub struct UpgradeTo {
     /// Where to upgrade to. If no subcommand given, `rolling-release` is assumed.
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     pub source: Option<UpgradeSource>,
 }
 
 /// Version-specifiers of different upgrade targets.
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum UpgradeSource {
     /// Upgrade to the current rolling-release version, will be
     /// fetched from git and built locally. rolling-release is
     /// expected to be more stable than canon. (default)
-    #[structopt(name = "rolling-release")]
     RollingRelease,
 
     /// Upgrade to the current version from the canon (previously: master) branch,
     /// which will be fetched from git and built locally.
-    #[structopt(name = "canon")]
     Canon,
 
     /// Alias for `canon`.
-    #[structopt(name = "master")]
     Master,
 
     /// Upgrade to the specified git branch, which will be fetched
     /// and built locally.
-    #[structopt(name = "branch")]
     Branch(BranchDest),
 
     /// Upgrade to a version in an arbitrary local directory.
-    #[structopt(name = "local")]
     Local(LocalDest),
 }
 
 /// Install an arbitrary version of lorri from a local directory.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct LocalDest {
     /// the path to a local check out of lorri.
-    #[structopt(parse(from_os_str))]
+    #[arg(long)]
     pub path: PathBuf,
 }
 
 /// Install an arbitrary version of Lorri from an upstream git branch.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct BranchDest {
     /// the path to git branch of the upstream repository.
     pub branch: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 #![allow(dropping_copy_types, clippy::zero_ptr)]
 
 #[macro_use]
-extern crate structopt;
-#[macro_use]
 extern crate serde_derive;
 
 pub mod build_loop;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use lorri::cli::{Arguments, Command, Internal_, Verbosity};
 use lorri::ops;
 use lorri::ops::error::ExitError;
@@ -10,7 +11,6 @@ use std::io::Write;
 use std::panic::PanicHookInfo;
 use std::path::Path;
 use std::{env, mem, panic};
-use structopt::StructOpt;
 
 use anyhow::anyhow;
 use backtrace::Backtrace;
@@ -23,7 +23,7 @@ async fn main() {
     setup_panic();
 
     let exit_code = {
-        let opts = Arguments::from_args();
+        let opts = Arguments::parse();
 
         let verbosity = match opts.verbosity {
             // -v flag was given 0 times

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -620,7 +620,7 @@ PS1="(lorri) ${PS1}"
 }
 
 /// Options for the kinds of events to report
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum EventKind {
     /// Report only live events - those that happen after invocation
     Live,

--- a/src/ops/error.rs
+++ b/src/ops/error.rs
@@ -1,6 +1,6 @@
 //! Exit errors returned from an op.
 
-use structopt::clap;
+use clap;
 
 /// Non-zero exit status from an op.
 ///
@@ -115,8 +115,8 @@ impl From<std::io::Error> for ExitError {
     }
 }
 
-impl From<clap::Error> for ExitError {
-    fn from(err: clap::Error) -> Self {
+impl From<clap::error::Error> for ExitError {
+    fn from(err: clap::error::Error) -> Self {
         ExitError::user_error(err)
     }
 }


### PR DESCRIPTION
Hello,

This PR replace `structopt` with the latest `clap` version. For now it's building and all the test are passing using `cargo build` and `cargo test`, but when I try to run `nix-build` the `clap_lex` crate fail to build with the following error:

```
error: builder for '/nix/store/dpqi499fkpb0iz3rbckvci7nrh1f6vdc-rust_clap_lex-0.7.2.drv' failed with exit code 1;
       last 25 log lines:
       >     |
       > 235 |                 OsStr::from_encoded_bytes_unchecked(second),
       >     |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `OsStr`
       >
       > error[E0599]: no method named `as_encoded_bytes` found for reference `&OsStr` in the current scope
       >    --> src/ext.rs:277:24
       >     |
       > 277 |         let bytes = os.as_encoded_bytes();
       >     |                        ^^^^^^^^^^^^^^^^ method not found in `&OsStr`
       >
       > error[E0599]: no function or associated item named `from_encoded_bytes_unchecked` found for struct `OsStr` in the current scope
       >    --> src/ext.rs:280:20
       >     |
       > 280 |             OsStr::from_encoded_bytes_unchecked(first),
       >     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `OsStr`
       >
       > error[E0599]: no function or associated item named `from_encoded_bytes_unchecked` found for struct `OsStr` in the current scope
       >    --> src/ext.rs:281:20
       >     |
       > 281 |             OsStr::from_encoded_bytes_unchecked(second),
       >     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `OsStr`
       >
       > error: aborting due to 11 previous errors
       >
       > For more information about this error, try `rustc --explain E0599`.
       For full logs, run 'nix log /nix/store/dpqi499fkpb0iz3rbckvci7nrh1f6vdc-rust_clap_lex-0.7.2.drv'.
error: 1 dependencies of derivation '/nix/store/xh0q0zr9c09k4fwf44px0c5g361xs10d-lorri.drv' failed to build
```

clap has a MSRV set at `1.74.0`, and those functions were added in rust `1.74.0` so this should work since nixos `24.05` is using rust `1.77.2`.

I think it's mainly a lack of nix experience and skill here. @nyarly if you have a couple of minutes, could you tell me if the rust version used to build this project is pinned to something older then `1.74.0`, and or what would be the way to know which version of rust `nix-build` is using?

EDIT: I found it, `nixpkgs` were still pinned to `23.11`. I update `nix/update-nixpkgs.sh` and run it. Now it builds :tada: 

Fixes #105 

- [ ] Amended the changelog in `release.nix` (see `release.nix` for instructions)
